### PR TITLE
タスクを作成日時順に並べる

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@ class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
   def index
-    @tasks = Task.all
+    @tasks = Task.order(created_at: 'DESC')
   end
 
   def new

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,4 +1,8 @@
 class Task < ApplicationRecord
   enum importance: { 低: 0, 中: 1, 高: 2 }
   enum status: { 未着手: 0, 着手: 1, 完了: 2 }
+
+  def created_at_day
+    self.created_at.strftime('%Y/%m/%d')
+  end
 end

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -2,17 +2,19 @@ h1 id="title_log" タスク一覧
 
 table.all_tasks
   tr
-    th タイトル
-    th 優先順位
-    th 状態
-    th 期限
-    th 説明文
-    th 個別リンク
+    th = t("actionview.task.index.title")
+    th = t("actionview.task.index.importance")
+    th = t("actionview.task.index.status")
+    th = t("actionview.task.index.dead_line_on")
+    th = t("actionview.task.index.detail")
+    th = t("actionview.task.index.created_at_day")
+    th = t("actionview.task.index.link")
   -@tasks.each do |task|
     tr.task
-      th #{task.title}
-      th #{task.importance}
-      th #{task.status}
-      th #{task.dead_line_on}
-      th #{task.detail}
+      th.title = task.title
+      th.importance = task.importance
+      th.status = task.status
+      th.dead_line_on = task.dead_line_on
+      th.detail = task.detail
+      th.created_day = task.created_at_day
       th = link_to "タスクの詳細", task_path(task.id)

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -8,7 +8,17 @@ ja:
         importance: 優先順位
         dead_line_on: 期限
         status: 状態
-        detail: 詳細
+        detail: 説明文
+  actionview:
+    task:
+      index:
+        title: タイトル
+        importance: 優先順位
+        dead_line_on: 期限
+        status: 状態
+        detail: 説明文
+        created_at_day: 作成日
+        link: 個別リンク
     errors:
       messages:
         record_invalid: "バリデーションに失敗しました: %{errors}"

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -4,7 +4,7 @@ FactoryBot.define do
     importance 0
     dead_line_on "2018-07-31"
     status 0
-    detail "ifinity_task..."
+    detail "infinity_task..."
     
   end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -2,49 +2,64 @@ require 'rails_helper'
 
 RSpec.feature"Tasks",type: :feature do
   given(:task) { FactoryBot.create(:task) }
-  given(:task_1) { FactoryBot.create(:task) }
-  background do
-    visit tasks_path
-  end
-
-  describe "タスクの一覧表示" do
+  describe "タスクの一覧に対する操作" do
     before do
-      expect(page).to have_content @tasks
+      FactoryBot.create(:task, title: "2番目", created_at: "2017/08/01 16:00::55")
+      FactoryBot.create(:task, title: "1番目", created_at: "2018/08/03 09:00:00")
+      visit tasks_path
     end
-    it "indexページに投稿されたタスクの一覧が表示される" do
-      all('task').each do |task|
-        expect(page).to have_content task.title
-        expect(page).to have_content task.importance
-        expect(page).to have_content task.status
-        expect(page).to have_content task.dead_line_on
-        expect(page).to have_content task.detail
-      end
-    end
-  end
 
-  describe "タスクの投稿" do
-    context "必要な値を入力している場合" do
-      before do
-        click_link "タスクの投稿"
-        fill_in 'task_title', with: 'feature_test'
-        select '高', from: 'task_importance'
-        select '2018', from: 'task_dead_line_on_1i'
-        select '8', from: 'task_dead_line_on_2i'
-        select '2', from: 'task_dead_line_on_3i'
-        select '着手', from: 'task_status'
-        fill_in 'task_detail', with: 'feature_specのテストです'
-        click_button '新しいタスクを追加'
+    describe "タスクの一覧表示" do
+      it "indexページに投稿されたタスクの一覧が表示される" do
+        all('table tr.task').each do
+          expect(page).to have_content "2番目"
+          expect(page).to have_content "低"
+          expect(page).to have_content "未着手"
+          expect(page).to have_content "2018-07-31"
+          expect(page).to have_content "infinity_task..."
+          expect(page).to have_content "1番目"
+          expect(page).to have_content "低"
+          expect(page).to have_content "未着手"
+          expect(page).to have_content "2018-07-31"
+          expect(page).to have_content "infinity_task..."
+        end
       end
-      it "新しいタスクの投稿に成功" do
-        expect(page).to have_content "新しいタスクが作成されました"
+      it "タスクの一覧は作成日が新しい順に並んでいる" do
+        within all('table tr.task')[0] do
+          expect(find('th.created_day')).to have_content "2018/08/03"
+        end
+        within all('table tr.task')[1] do
+          expect(find('th.created_day')).to have_content  "2017/08/01"
+        end
+      end
+    end
+
+    describe "タスクの投稿" do
+      context "必要な値を入力している場合" do
+        before do
+          click_link "タスクの投稿"
+          fill_in 'task_title', with: 'feature_test'
+          select '高', from: 'task_importance'
+          select '2018', from: 'task_dead_line_on_1i'
+          select '8', from: 'task_dead_line_on_2i'
+          select '2', from: 'task_dead_line_on_3i'
+          select '着手', from: 'task_status'
+          fill_in 'task_detail', with: 'feature_specのテストです'
+          click_button '新しいタスクを追加'
+        end
+        it "新しいタスクの投稿に成功" do
+          expect(page).to have_content "新しいタスクが作成されました"
+        end
       end
     end
   end
 
   describe "個別のタスクに対して行う操作" do
-    background do
+    before do
+      visit tasks_path
       visit task_path(task.id)
     end
+
     describe "タスクの編集と更新" do
       context "必要な値を入力している場合" do
         before do


### PR DESCRIPTION
## やったこと
- タスクを一覧表示する際に、作成日時が新しいもの順に並ぶように設定
  - feature_specによる挙動確認テストも行う
- タスクの一覧表示画面で、作成日時という情報も表示されるように設定
- I18化の修正