### PR TITLE
validationの設定とviewの修正

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -10,10 +10,11 @@ class TasksController < ApplicationController
   end
 
   def create
-    if Task.create(task_params)
+    @task = Task.new(task_params)
+    if @task.save
       redirect_to tasks_path, notice: "新しいタスクが作成されました"
     else
-      render :new, alert: "タスクの作成に失敗しました"
+      render :new
     end
   end
 
@@ -27,7 +28,7 @@ class TasksController < ApplicationController
     if @task.update(task_params)
       redirect_to tasks_path, notice: "タスクの内容が変更されました"
     else
-      render :edit, alert: "タスクの内容の変更に失敗しました"
+      render :edit
     end
   end
 

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -2,7 +2,18 @@ class Task < ApplicationRecord
   enum importance: { 低: 0, 中: 1, 高: 2 }
   enum status: { 未着手: 0, 着手: 1, 完了: 2 }
 
+  validates :title, presence: true, length: {maximum: 30}
+  validates :importance, inclusion: { in: %w(低 中 高) }
+  validates :status, inclusion: { in: %w(未着手 着手 完了) }
+  validate :dead_line_on_cannot_be_in_the_past
+
   def created_at_day
     self.created_at.strftime('%Y/%m/%d')
+  end
+
+  def dead_line_on_cannot_be_in_the_past
+    if dead_line_on.present? && dead_line_on < Date.today
+      errors.add(:dead_line_on, "に過去の日付は使用できません")
+    end
   end
 end

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -16,5 +16,5 @@ html
         span = link_to "タスクの投稿", new_task_path
     - flash.each do |key, value|
       .alert.alert-#{key}
-        = value
+        p = value
     = yield

--- a/app/views/tasks/_task_form.slim
+++ b/app/views/tasks/_task_form.slim
@@ -1,4 +1,8 @@
 = form_for task do |f|
+  - if task.errors.any?
+    .error_announce
+      - task.errors.full_messages.each do |error_message|
+        p = error_message
   .title_block
     = f.label :title
     = f.text_field :title, placeholder: "タイトル"

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -1,8 +1,8 @@
 FactoryBot.define do
   factory :task do
-    title "TaskFactory"
+    title "東京オリンピック開会日"
     importance 0
-    dead_line_on "2018-07-31"
+    dead_line_on "2020-07-24"
     status 0
     detail "infinity_task..."
     

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -4,8 +4,8 @@ RSpec.feature"Tasks",type: :feature do
   given(:task) { FactoryBot.create(:task) }
   describe "タスクの一覧に対する操作" do
     before do
-      FactoryBot.create(:task, title: "2番目", created_at: "2017/08/01 16:00::55")
-      FactoryBot.create(:task, title: "1番目", created_at: "2018/08/03 09:00:00")
+      FactoryBot.create(:task, title: "2番目", dead_line_on: "2020-07-24", created_at: "2020/07/24 16:00::55")
+      FactoryBot.create(:task, title: "1番目", dead_line_on: "2020-08-09", created_at: "2020/08/09 09:00:00")
       visit tasks_path
     end
 
@@ -15,21 +15,21 @@ RSpec.feature"Tasks",type: :feature do
           expect(page).to have_content "2番目"
           expect(page).to have_content "低"
           expect(page).to have_content "未着手"
-          expect(page).to have_content "2018-07-31"
+          expect(page).to have_content "2020-07-24"
           expect(page).to have_content "infinity_task..."
           expect(page).to have_content "1番目"
           expect(page).to have_content "低"
           expect(page).to have_content "未着手"
-          expect(page).to have_content "2018-07-31"
+          expect(page).to have_content "2020-08-09"
           expect(page).to have_content "infinity_task..."
         end
       end
       it "タスクの一覧は作成日が新しい順に並んでいる" do
         within all('table tr.task')[0] do
-          expect(find('th.created_day')).to have_content "2018/08/03"
+          expect(find('th.created_day')).to have_content "2020/08/09"
         end
         within all('table tr.task')[1] do
-          expect(find('th.created_day')).to have_content  "2017/08/01"
+          expect(find('th.created_day')).to have_content  "2020/07/24"
         end
       end
     end
@@ -40,15 +40,63 @@ RSpec.feature"Tasks",type: :feature do
           click_link "タスクの投稿"
           fill_in 'task_title', with: 'feature_test'
           select '高', from: 'task_importance'
-          select '2018', from: 'task_dead_line_on_1i'
-          select '8', from: 'task_dead_line_on_2i'
-          select '2', from: 'task_dead_line_on_3i'
+          select '2020', from: 'task_dead_line_on_1i'
+          select '7', from: 'task_dead_line_on_2i'
+          select '24', from: 'task_dead_line_on_3i'
           select '着手', from: 'task_status'
-          fill_in 'task_detail', with: 'feature_specのテストです'
+          fill_in 'task_detail', with: '東京オリンピック開会日'
           click_button '新しいタスクを追加'
         end
-        it "新しいタスクの投稿に成功" do
+        it "タスクの作成に成功する" do
           expect(page).to have_content "新しいタスクが作成されました"
+        end
+      end
+      context "task_titleが空の場合" do
+        before do
+          click_link "タスクの投稿"
+          fill_in 'task_title', with: nil
+          select '高', from: 'task_importance'
+          select '2020', from: 'task_dead_line_on_1i'
+          select '7', from: 'task_dead_line_on_2i'
+          select '24', from: 'task_dead_line_on_3i'
+          select '着手', from: 'task_status'
+          fill_in 'task_detail', with: '東京オリンピック開会日'
+          click_button '新しいタスクを追加'
+        end
+        it "タスクの投稿に失敗する" do
+          expect(page).to have_content "タイトルを入力してください"
+        end
+      end
+      context "task_titleが30文字以上の場合" do
+        before do
+          click_link "タスクの投稿"
+          fill_in 'task_title', with: "12345678910/12345678910/12345678910"
+          select '高', from: 'task_importance'
+          select '2020', from: 'task_dead_line_on_1i'
+          select '7', from: 'task_dead_line_on_2i'
+          select '24', from: 'task_dead_line_on_3i'
+          select '着手', from: 'task_status'
+          fill_in 'task_detail', with: '東京オリンピック開会日'
+          click_button '新しいタスクを追加'
+        end
+        it "タスクの投稿に失敗する" do
+          expect(page).to have_content "タイトルは30文字以内で入力してください"
+        end
+      end
+      context "dead_line_onの日付が過去の日付の場合" do
+        before do
+          click_link "タスクの投稿"
+          fill_in 'task_title', with: 'feature_test'
+          select '高', from: 'task_importance'
+          select '2016', from: 'task_dead_line_on_1i'
+          select '8', from: 'task_dead_line_on_2i'
+          select '5', from: 'task_dead_line_on_3i'
+          select '着手', from: 'task_status'
+          fill_in 'task_detail', with: 'リオデジャネイロオリンピック開会日'
+          click_button '新しいタスクを追加'
+        end
+        it "タスクの投稿に失敗する" do
+          expect(page).to have_content "期限に過去の日付は使用できません"
         end
       end
     end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -1,5 +1,42 @@
 require 'rails_helper'
 
 RSpec.describe Task, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe "Taskのバリデーション" do
+    context "titleが30文字以内で入力されている場合" do
+      it "保存できる" do
+        task = FactoryBot.build(:task)
+        expect(task.valid?).to eq true
+      end
+    end
+    context "titleの値がnilの場合" do
+      it "保存できない" do
+        task = FactoryBot.build(:task, title: nil)
+        expect(task.valid?).to eq false
+      end
+    end
+    context "titleが30文字以上の場合" do
+      it "保存できない" do
+        task = FactoryBot.build(:task, title: "12345678910/12345678910/12345678910")
+        expect(task.valid?).to eq false
+      end
+    end
+    context "importanceが(低, 中, 高)以外の場合" do
+      it "作成できない" do
+        expect{FactoryBot.build(:task, importance: "sasa")}.to raise_error(ArgumentError)
+        expect{ FactoryBot.build(:task, importance: 99)}.to raise_error(ArgumentError)
+      end
+    end
+    context "statusが(未着手, 着手, 完了)以外の場合" do
+      it "作成できない" do
+        expect{FactoryBot.build(:task, status: "sasa")}.to raise_error(ArgumentError)
+        expect{FactoryBot.build(:task, status: 99)}.to raise_error(ArgumentError)
+      end
+    end
+    context "期限が過去の日付の場合" do
+      it "作成できない" do
+        task = FactoryBot.build(:task, dead_line_on: "2008-09-25")
+        expect(task.valid?).to eq false
+      end
+    end
+  end
 end


### PR DESCRIPTION
###やったこと
- Taskモデルに対するValidationの設定
  - titleが空、もしくは30文字以上の場合はタスクの投稿ができないように設定
  - importance、statusの値が不正な値の場合、タスクの投稿ができないように設定
  - dead_line_onの日付が過去の日付の場合、タスクの投稿ができないように設定

- 設定したValidationが正しく機能するかを、rspecでテストする

- Validationで投稿に失敗したら、エラーメッセージが表示されるように設定し、rspecで正しく機能するかをテスト