### PR TITLE
herokuでのbasic認証機能を追加

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,2 +1,5 @@
 class ApplicationController < ActionController::Base
+  http_basic_authenticate_with name: ENV['BASIC_AUTH_USERNAME'], password: ENV['BASIC_AUTH_PASSWORD'] if Rails.env == "production"
 end
+
+


### PR DESCRIPTION
## やったこと
- heroku上で、アプリを利用する前にbasic認証が行われるように設定