### PR TITLE
Add search tasks func

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -59,6 +59,7 @@ group :development do
 end
 
 gem 'slim-rails', '~> 3.1', '>= 3.1.1'
+gem 'ransack'
 
 gem 'webpacker', github: 'rails/webpacker'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -166,6 +166,11 @@ GEM
       rake (>= 0.8.7)
       thor (>= 0.18.1, < 2.0)
     rake (12.3.1)
+    ransack (2.0.0)
+      actionpack (>= 5.0)
+      activerecord (>= 5.0)
+      activesupport (>= 5.0)
+      i18n
     rb-fsevent (0.10.3)
     rb-inotify (0.9.10)
       ffi (>= 0.5.0, < 2)
@@ -258,6 +263,7 @@ DEPENDENCIES
   puma (~> 3.11)
   rails (~> 5.2.0)
   rails-controller-testing
+  ransack
   rspec-rails
   sass-rails (~> 5.0)
   selenium-webdriver (>= 3.1.0)

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,10 +1,6 @@
 class TasksController < ApplicationController
   before_action :set_task, only: [:show, :edit, :update, :destroy]
 
-  # def index
-  #   @tasks = Task.order(created_at: 'DESC')
-  # end
-
   def new
     @task = Task.new
   end
@@ -16,9 +12,6 @@ class TasksController < ApplicationController
     else
       render :new
     end
-  end
-
-  def show
   end
 
   def edit

--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -3,23 +3,56 @@ import axios from 'axios';
 import lodash from 'lodash';
 
 new Vue ({
-  el: '#all_tasks',
-  data: {
-    tasks: []
-  },
-  methods: {
-    orderdByCreatedDay: function() {
-      this.tasks = _.orderBy(this.tasks, 'created_at', 'desc')
+    el: '#all_tasks',
+    data: {
+        tasks: [],
+        searchQuery: '',
+        selected: '',
+        createdOrder: false,
+        deadLineOrder: true
     },
-    orderdByDeadLine: function() {
-        this.tasks = _.orderBy(this.tasks, 'dead_line_on')
+    methods: {
+        orderCreatedDayByDesc: function () {
+            this.tasks = _.orderBy(this.tasks, 'created_at', 'desc')
+            this.createdOrder = true
+        },
+        orderCreatedDayByAsc: function () {
+            this.tasks = _.orderBy(this.tasks, 'created_at')
+            this.createdOrder = false
+        },
+        orderDeadLineByDesc: function () {
+            this.tasks = _.orderBy(this.tasks, 'dead_line_on', 'desc')
+            this.deadLineOrder = true
+        },
+        orderDeadLineByAsc: function () {
+            this.tasks = _.orderBy(this.tasks, 'dead_line_on')
+            this.deadLineOrder = false
+        },
+        search: function () {
+            this.searchTitle()
+            this.searchSelected()
+        },
+        searchTitle: function() {
+            this.tasks = this.tasks.filter(task => task.title.match(this.searchQuery) )
+        },
+        searchSelected: function () {
+            console.log(typeof this.tasks[0].status)
+            console.log(typeof this.selected)
+            this.tasks = this.tasks.filter(task => task.status.match(this.selected) )
+        },
+        getTasks: function(){
+            axios.get('api/tasks.json').then(function (response) {
+                this.tasks = response.data
+            }.bind(this)).catch(function (e) {
+                console.error(e)
+            })
+        },
+        reset: function(){
+            this.getTasks();
+        }
+    },
+    created: function () {
+        this.getTasks();
     }
-  },
-  created: function() {
-    axios.get('api/tasks.json').then(function(response) {
-      this.tasks = response.data
-    }.bind(this)).catch(function(e) {
-      console.error(e)
-    })
-  }
 })
+

--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -8,7 +8,7 @@ new Vue ({
         tasks: [],
         searchQuery: '',
         selected: '',
-        createdOrder: false,
+        createdOrder: true,
         deadLineOrder: true
     },
     methods: {
@@ -36,9 +36,7 @@ new Vue ({
             this.tasks = this.tasks.filter(task => task.title.match(this.searchQuery) )
         },
         searchSelected: function () {
-            console.log(typeof this.tasks[0].status)
-            console.log(typeof this.selected)
-            this.tasks = this.tasks.filter(task => task.status.match(this.selected) )
+            this.tasks = (this.selected != '') ? this.tasks.filter( task => task.status.match(new RegExp('^' + this.selected + '$')) ) : this.tasks
         },
         getTasks: function(){
             axios.get('api/tasks.json').then(function (response) {
@@ -49,6 +47,8 @@ new Vue ({
         },
         reset: function(){
             this.getTasks();
+            this.searchQuery = ''
+            this.selected = ''
         }
     },
     created: function () {

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,8 +1,23 @@
 h1 id="title_log" タスク一覧
 
 #all_tasks
-  button v-on:click="orderdByCreatedDay" 投稿日時順
-  button v-on:click="orderdByDeadLine" 期限順
+  .order_sort v-if="createdOrder"
+    button v-on:click="orderCreatedDayByAsc" 投稿日が昔順に並べる
+  .order_sort [v-else]
+    button v-on:click="orderCreatedDayByDesc" 投稿日が新しい順に並べる
+  .order_dead_line v-if="deadLineOrder"
+    button v-on:click="orderDeadLineByAsc" 期限が近い順に並べる
+  .order_dead_line [v-else]
+    button v-on:click="orderDeadLineByDesc" 期限が新しい順に並べる
+
+  input v-model="searchQuery"
+  select v-model="selected"
+    option = ''
+    option = "未着手"
+    option = "着手"
+    option = "完了"
+  button v-on:click="search" 検索
+  button v-on:click="reset" 検索条件をリセット
   table
     tr
       th = t("actionview.task.index.title")

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -2,16 +2,16 @@ h1 id="title_log" タスク一覧
 
 #all_tasks
   .order_sort v-if="createdOrder"
-    button v-on:click="orderCreatedDayByAsc" 投稿日が昔順に並べる
+    button v-on:click="orderCreatedDayByAsc" 投稿日が古い順
   .order_sort [v-else]
-    button v-on:click="orderCreatedDayByDesc" 投稿日が新しい順に並べる
+    button v-on:click="orderCreatedDayByDesc" 投稿日が新しい順
   .order_dead_line v-if="deadLineOrder"
-    button v-on:click="orderDeadLineByAsc" 期限が近い順に並べる
+    button v-on:click="orderDeadLineByAsc" 期限が近い順
   .order_dead_line [v-else]
-    button v-on:click="orderDeadLineByDesc" 期限が新しい順に並べる
+    button v-on:click="orderDeadLineByDesc" 期限が遠い順
 
-  input v-model="searchQuery"
-  select v-model="selected"
+  input v-model="searchQuery" id="search_form"
+  select v-model="selected" name="search_status" id="search_status"
     option = ''
     option = "未着手"
     option = "着手"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,10 @@ Rails.application.routes.draw do
   root to: "tasks#index"
 
   namespace :api do
-    resources :tasks
+    resources :tasks do
+      collection do
+        get 'search'
+      end
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,11 +4,8 @@ Rails.application.routes.draw do
   resources :tasks
   root to: "tasks#index"
 
+
   namespace :api do
-    resources :tasks do
-      collection do
-        get 'search'
-      end
-    end
+    resources :tasks, only: [:index]
   end
 end


### PR DESCRIPTION
## やったこと
・タスク一覧画面で、タイトルの名前で部分検索を行う機能とタスクの状態を用いてフィルター検索を行う機能の追加

・「検索条件をリセット」というボタンを置き、複数の項目の検索で失敗した時もすぐに元の状態に戻せるようにした

・検索した後、表示されたタスクにも並び替えができるような仕様にした

・feature_specを用いたテストを行い、パスした