### PR TITLE
優先順位順に並べられる機能を追加

### DIFF
--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -9,34 +9,46 @@ new Vue ({
         searchQuery: '',
         selected: '',
         createdOrder: true,
-        deadLineOrder: true
+        deadLineOrder: false,
+        importanceOrder: true
     },
     methods: {
-        orderCreatedDayByDesc: function () {
-            this.tasks = _.orderBy(this.tasks, 'created_at', 'desc')
-            this.createdOrder = true
+        orderByCreatedDay: function () {
+            (this.createdOrder) ? (
+                this.tasks = _.orderBy(this.tasks, 'created_at', 'desc'),
+                this.createdOrder = !this.createdOrder
+            ) : (
+                this.tasks = _.orderBy(this.tasks, 'created_at'),
+                this.createdOrder = !this.createdOrder
+            )
         },
-        orderCreatedDayByAsc: function () {
-            this.tasks = _.orderBy(this.tasks, 'created_at')
-            this.createdOrder = false
+        orderByDeadLine: function () {
+            (this.deadLineOrder) ? (
+                this.tasks = _.orderBy(this.tasks, 'dead_line_on', 'desc'),
+                this.deadLineOrder = !this.deadLineOrder
+            ) : (
+                this.tasks = _.orderBy(this.tasks, 'dead_line_on'),
+                this.deadLineOrder = !this.deadLineOrder
+            )
         },
-        orderDeadLineByDesc: function () {
-            this.tasks = _.orderBy(this.tasks, 'dead_line_on', 'desc')
-            this.deadLineOrder = true
-        },
-        orderDeadLineByAsc: function () {
-            this.tasks = _.orderBy(this.tasks, 'dead_line_on')
-            this.deadLineOrder = false
+        orderByImportance: function () {
+            (this.importanceOrder) ? (
+                this.tasks = _.orderBy(this.tasks, 'importance.rank', 'desc'),
+                this.importanceOrder = !this.importanceOrder
+            ) : (
+                this.tasks = _.orderBy(this.tasks, 'importance.rank'),
+                this.importanceOrder = !this.importanceOrder
+            )
         },
         search: function () {
-            this.searchTitle()
-            this.searchSelected()
+            this.searchByTitle()
+            this.searchBySelected()
         },
-        searchTitle: function() {
+        searchByTitle: function() {
             this.tasks = this.tasks.filter(task => task.title.match(this.searchQuery) )
         },
-        searchSelected: function () {
-            this.tasks = (this.selected != '') ? this.tasks.filter( task => task.status.match(new RegExp('^' + this.selected + '$')) ) : this.tasks
+        searchBySelected: function () {
+            this.tasks = (this.selected != '') ? this.tasks.filter( task => task.status.num == this.selected ) : this.tasks
         },
         getTasks: function(){
             axios.get('api/tasks.json').then(function (response) {

--- a/app/views/api/tasks/index.json.jbuilder
+++ b/app/views/api/tasks/index.json.jbuilder
@@ -1,9 +1,15 @@
 json.array! @tasks do |task|
   json.id task.id
   json.title task.title
-  json.importance task.importance
+  json.importance do
+    json.text task.importance
+    json.rank task.importance_before_type_cast
+  end
   json.dead_line_on task.dead_line_on
-  json.status task.status
+  json.status do
+    json.text task.status
+    json.num task.status_before_type_cast
+  end
   json.detail task.detail
   json.created_at task.created_at.strftime('%Y/%m/%d')
 end

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,21 +1,19 @@
 h1 id="title_log" タスク一覧
 
 #all_tasks
-  .order_sort v-if="createdOrder"
-    button v-on:click="orderCreatedDayByAsc" 投稿日が古い順
-  .order_sort [v-else]
-    button v-on:click="orderCreatedDayByDesc" 投稿日が新しい順
-  .order_dead_line v-if="deadLineOrder"
-    button v-on:click="orderDeadLineByAsc" 期限が近い順
-  .order_dead_line [v-else]
-    button v-on:click="orderDeadLineByDesc" 期限が遠い順
+  .order_sort
+    button v-on:click="orderByCreatedDay" 投稿日順
+  .order_dead_line
+    button v-on:click="orderByDeadLine" 期限日順
+  .order_importance
+    button v-on:click="orderByImportance" 優先順位順
 
   input v-model="searchQuery" id="search_form"
   select v-model="selected" name="search_status" id="search_status"
-    option = ''
-    option = "未着手"
-    option = "着手"
-    option = "完了"
+    option value='' 選択しない
+    option value="0" 未着手
+    option value="1" 着手
+    option value="2" 完了
   button v-on:click="search" 検索
   button v-on:click="reset" 検索条件をリセット
   table
@@ -29,8 +27,8 @@ h1 id="title_log" タスク一覧
       th = t("actionview.task.index.link")
     tr.tasks v-for="task in tasks"
       th.title = "{{task.title}}"
-      th.importance = "{{task.importance}}"
-      th.status = "{{task.status}}"
+      th.importance = "{{task.importance.text}}"
+      th.status = "{{task.status.text}}"
       th.dead_line_on = "{{task.dead_line_on}}"
       th.detail = "{{task.detail}}"
       th.created_day = "{{task.created_at}}"

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -4,8 +4,8 @@ RSpec.feature"Tasks",type: :feature do
   given(:task) { FactoryBot.create(:task) }
   describe "タスクの一覧に対する操作" do
     before do
-      FactoryBot.create(:task, title: "2番目", dead_line_on: "2020-07-24", status: 0, created_at: "2020/07/24 16:00::55")
-      FactoryBot.create(:task, title: "1番目", dead_line_on: "2020-08-09", status: 1, created_at: "2020/08/09 09:00:00")
+      FactoryBot.create(:task, title: "2番目", importance: 2, status: 0, dead_line_on: "2020-07-24", created_at: "2020/07/24 16:00::55")
+      FactoryBot.create(:task, title: "1番目", importance: 1, status: 1, dead_line_on: "2020-08-09", created_at: "2020/08/09 09:00:00")
       visit tasks_path
     end
 
@@ -13,18 +13,18 @@ RSpec.feature"Tasks",type: :feature do
       it "indexページに投稿されたタスクの一覧が表示される" do
         all('table tr.task').each do
           expect(page).to have_content "2番目"
-          expect(page).to have_content "低"
+          expect(page).to have_content "高"
           expect(page).to have_content "未着手"
           expect(page).to have_content "2020-07-24"
           expect(page).to have_content "infinity_task..."
           expect(page).to have_content "1番目"
-          expect(page).to have_content "低"
+          expect(page).to have_content "中"
           expect(page).to have_content "着手"
           expect(page).to have_content "2020-08-09"
           expect(page).to have_content "infinity_task..."
         end
       end
-      it "タスクの一覧は投稿日が新しい順に並んでいる", js: true do
+      it "ページ遷移後、投稿日が新しい順に並んでいる", js: true do
         within all('table tr.tasks')[0] do
           # スクリーンショットをとって確認する方法、やって見る
           expect(find('th.created_day')).to have_content "2020/08/09"
@@ -36,45 +36,89 @@ RSpec.feature"Tasks",type: :feature do
     end
 
     describe "タスクの並び替え", js: true do
-      it "期限が近い順に並び替える" do
-        click_button '期限が近い順'
-        sleep 0.5
-        within all('table tr.tasks')[0] do
-          expect(find('th.dead_line_on')).to have_content "2020-07-24"
+      context "投稿日が新しい順" do
+        before do
+          click_button '投稿日順'
         end
-        within all('table tr.tasks')[1] do
-          expect(find('th.dead_line_on')).to have_content  "2020-08-09"
-        end
-      end
-      it "期限が遠い順に並べる" do
-        click_button '期限が近い順'
-        click_button '期限が遠い順'
-        within all('table tr.tasks')[0] do
-          expect(find('th.dead_line_on')).to have_content "2020-08-09"
-        end
-        within all('table tr.tasks')[1] do
-          expect(find('th.dead_line_on')).to have_content "2020-07-24"
+        it "投稿日が昔順に並び替える" do
+          within all('table tr.tasks')[0] do
+            expect(find('th.created_day')).to have_content "2020/08/09"
+          end
+          within all('table tr.tasks')[1] do
+            expect(find('th.created_day')).to have_content  "2020/07/24"
+          end
         end
       end
-      it "投稿日が昔順に並び替える" do
-        click_button '投稿日が古い順'
-        sleep 0.5
-        within all('table tr.tasks')[0] do
-          expect(find('th.created_day')).to have_content "2020/07/24"
+
+      context "投稿日が古い順" do
+        before do
+          click_button '投稿日順'
+          click_button '投稿日順'
         end
-        within all('table tr.tasks')[1] do
-          expect(find('th.created_day')).to have_content  "2020/08/09"
+        it "投稿日が昔新しい順に並び替える" do
+          within all('table tr.tasks')[0] do
+            expect(find('th.created_day')).to have_content "2020/07/24"
+          end
+          within all('table tr.tasks')[1] do
+            expect(find('th.created_day')).to have_content  "2020/08/09"
+          end
         end
       end
-      it "投稿日が昔順に並べた後、新しい順に並び替える" do
-        click_button '投稿日が古い順'
-        click_button '投稿日が新しい順'
-        sleep 0.5
-        within all('table tr.tasks')[0] do
-          expect(find('th.created_day')).to have_content "2020/08/09"
+
+      context "期限日が近い順" do
+        before do
+          click_button '期限日順'
         end
-        within all('table tr.tasks')[1] do
-          expect(find('th.created_day')).to have_content  "2020/07/24"
+        it "期限が近い順に並び替える" do
+          within all('table tr.tasks')[0] do
+            expect(find('th.dead_line_on')).to have_content "2020-07-24"
+          end
+          within all('table tr.tasks')[1] do
+            expect(find('th.dead_line_on')).to have_content  "2020-08-09"
+          end
+        end
+      end
+      context "期限日が遠いの順" do
+        before do
+          click_button '期限日順'
+          click_button '期限日順'
+        end
+        it "期限が遠い順に並び替える" do
+          within all('table tr.tasks')[0] do
+            expect(find('th.dead_line_on')).to have_content "2020-08-09"
+          end
+          within all('table tr.tasks')[1] do
+            expect(find('th.dead_line_on')).to have_content "2020-07-24"
+          end
+        end
+      end
+
+      context "優先度が高い順" do
+        before do
+          click_button '優先順位順'
+        end
+        it "優先度が高い順に並び替える" do
+          within all('table tr.tasks')[0] do
+            expect(find('th.importance')).to have_content "高"
+          end
+          within all('table tr.tasks')[1] do
+            expect(find('th.importance')).to have_content  "中"
+          end
+        end
+      end
+
+      context "優先度が低い順" do
+        before do
+          click_button '優先順位順'
+          click_button '優先順位順'
+        end
+        it "優先度が低い順に並び替える" do
+          within all('table tr.tasks')[0] do
+            expect(find('th.importance')).to have_content "中"
+          end
+          within all('table tr.tasks')[1] do
+            expect(find('th.importance')).to have_content  "高"
+          end
         end
       end
     end


### PR DESCRIPTION
やったこと
・タスク毎に[ 高、中、低 ]の中から優先順位を決められる様に設定
・優先順位によって、タスクをソートする機能を追加
・feature_specで動作確認を行う