### PR TITLE
featureテストが動く様に既存コードを修正

### DIFF
--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -13,10 +13,11 @@
 FactoryBot.define do
   factory :task do
     sequence(:title) { |n| "#{n}番目" }
-    importance 0
+    importance { 0 }
     sequence(:dead_line_on) { |n| "2020-07-#{n}"}
-    status 0
-    detail "infinity_task..."
+    status { 0 }
+    detail { "infinity_task..." }
   end
 end
+
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -1,6 +1,5 @@
 # This file is copied to spec/ when you run 'rails generate rspec:install'
 require 'spec_helper'
-require 'capybara-screenshot/rspec'
 ENV['RAILS_ENV'] ||= 'test'
 require File.expand_path('../../config/environment', __FILE__)
 # Prevent database truncation if the environment is production


### PR DESCRIPTION
## やったこと
誤って読み込んでいた、capybara_screen_shotを読み込まない様に変更

## merge先がmaster出ない理由
- update_outdated_gems ブランチとの変更差分を出したくなかったため。
- update_outdated_branchがmasterにmergeされた後、rebaseしてmasterに反映される様にする。