### PR TITLE
rspecでのテスト後、自動でテストデータが削除される様にする

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -47,6 +47,7 @@ group :development, :test do
   gem 'chromedriver-helper'
   gem 'pry-rails'
   gem 'pry-byebug'
+  gem 'database_rewinder'
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -89,6 +89,7 @@ GEM
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.5)
     crass (1.0.4)
+    database_rewinder (0.9.1)
     diff-lcs (1.3)
     erubi (1.8.0)
     execjs (2.7.0)
@@ -276,6 +277,7 @@ DEPENDENCIES
   capybara
   chromedriver-helper
   coffee-rails (~> 4.2)
+  database_rewinder
   factory_bot_rails
   faker
   jbuilder (~> 2.5)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -29,6 +29,14 @@ RSpec.configure do |config|
     expectations.include_chain_clauses_in_custom_matcher_descriptions = true
   end
 
+  config.before(:suite) do
+    DatabaseRewinder.clean_all
+  end
+
+  config.after(:each) do
+    DatabaseRewinder.clean
+  end
+
   # rspec-mocks config goes here. You can use an alternate test double
   # library (such as bogus or mocha) by changing the `mock_with` option here.
   config.mock_with :rspec do |mocks|


### PR DESCRIPTION
## やったこと
- database_rewinderというgemを追加
- rspecでのテスト後、テストdbのデータが削除される様に設定