### PR TITLE
status情報をbindする際のプロパティ名を変更

### DIFF
--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -59,13 +59,13 @@ window.tasks = new Vue ({
         },
         search: function () {
             this.searchByTitle()
-            this.searchBySelected()
+            this.searchByStatus()
         },
         searchByTitle: function() {
             this.tasks = this.tasks.filter(task => task.title.match(this.searchQuery) )
         },
-        searchBySelected: function () {
-            this.tasks = (this.selected != '') ? this.tasks.filter( task => task.status.num == this.selected ) : this.tasks
+        searchByStatus: function () {
+            this.tasks = (this.selectedStatus != '') ? this.tasks.filter( task => task.status.num == this.selectedStatus ) : this.tasks
         },
         getTasks: function(){
             axios.get(this.resource_url).then(function (response) {
@@ -78,7 +78,7 @@ window.tasks = new Vue ({
         reset: function(){
             this.getTasks();
             this.searchQuery = ''
-            this.selected = ''
+            this.selectedStatus = ''
         },
         updateResource: function(data) {
             this.tasks = data

--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -21,7 +21,7 @@ window.tasks = new Vue ({
             previous_button_text: 'Go Back'
         },
         searchQuery: '',
-        selected: '',
+        selectedStatus: '',
         createdOrder: true,
         deadLineOrder: false,
         importanceOrder: true

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -19,7 +19,7 @@
             .query
               input v-model="searchQuery" name="query" id="search_query"
             .status
-              select v-model="selected" name="status" id="search_status"
+              select v-model="selectedStatus" name="status" id="search_status"
                 option value='' 選択しない
                 option value="0" 未着手
                 option value="1" 着手


### PR DESCRIPTION
## やったこと
- view側とjs側で、status情報をbindする際のプロパティ名を変更
- js側のstatus情報を用いて、ソートするメソッド名を変更

## merge先が fix_feature_test_codeの理由
- 現在、masterだとテストができないため。テストを行い、問題なく動くかの確認ができるブランチからきる必要があっと
- fix_feature_test_codeブランチがmergeされた後、rebaseしてmasterにmergeする。