### PR TITLE
CircleCI の設定を追加

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,0 +1,56 @@
+version: 2
+jobs:
+  build:
+    parallelism: 3
+    docker:
+      - image: circleci/ruby:2.5-stretch-node-browsers
+        environment:
+          BUNDLE_JOBS: 3
+          BUNDLE_RETRY: 3
+          BUNDLE_PATH: vendor/bundle
+          DB_HOST: 127.0.0.1
+          DB_USERNAME: root
+          DB_PASSWORD: ""
+          RAILS_ENV: test
+      - image: circleci/mysql:5.7
+    steps:
+      - checkout
+      - run: mv config/database.yml.ci config/database.yml
+      - restore_cache:
+          keys:
+            - el-bundle-v2-{{ checksum "Gemfile.lock" }}
+            - el-bundle-v2-
+      - run: # Install Ruby dependencies
+         name: Bundle Install
+         command: bundle check || bundle install
+      - save_cache:
+          key: el-bundle-v2-{{ checksum "Gemfile.lock" }}
+          paths:
+            - vendor/bundle
+      - restore_cache:
+          keys:
+            - el-yarn-{{ checksum "yarn.lock" }}
+            - el-demo-yarn-
+      - run:
+          name: Yarn Install
+          command: yarn install --cache-folder ~/.cache/yarn
+      - save_cache:
+          key: el-yarn-{{ checksum "yarn.lock" }}
+          paths:
+            - ~/.cache/yarn
+      - run:
+          name: Wait for DB
+          command: dockerize -wait tcp://127.0.0.1:3306 -timeout 1m
+      - run:
+          name: Create DB
+          command: RAILS_ENV=test bin/rails db:create
+      - run:
+          name: Database setup
+          command: bin/rails db:schema:load --trace
+      - run:
+          name: Run rspec in parallel
+          command: |
+            bundle exec rspec --out test_results/rspec.xml \
+                              --format progress \
+                              $(circleci tests glob "spec/**/*_spec.rb" | circleci tests split --split-by=timings)
+

--- a/config/database.yml.ci
+++ b/config/database.yml.ci
@@ -1,0 +1,14 @@
+default: &default
+  adapter: mysql2
+  encoding: utf8
+  pool: <%= ENV.fetch("RAILS_MAX_THREADS") { 5 } %>
+  username: root
+  password: ""
+  host: localhost
+
+test:
+  <<: *default
+  database: el-training_test
+  host: <%= ENV['DB_HOST'] %>
+  username: root
+  password: ""

--- a/config/database.yml.ci
+++ b/config/database.yml.ci
@@ -10,5 +10,5 @@ test:
   <<: *default
   database: el-training_test
   host: <%= ENV['DB_HOST'] %>
-  username: root
-  password: ""
+  username: <%= ENV['DB_USERNAME'] %>
+  password: <%= ENV['DB_PASSWORD'] %>


### PR DESCRIPTION
ローカルで確認済み。これでいい感じに連携させると動く...はず。
Circle CIのRuby用コンテナイメージが2.5.5しかない（実はあるけどdeprecatedな）ので、**Rubyのバージョン2.5.5に上げる&Gemfile2.5.5指定に書き換える必要**があります。

こちらの手順に従ってGitHubと、CircleCiを連携させてください。
https://circleci.com/docs/2.0/enable-checks/