### PR TITLE
chore: bundlerのバージョン指定をしないと動かないので修正

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -5,6 +5,7 @@ jobs:
     docker:
       - image: circleci/ruby:2.5-stretch-node-browsers
         environment:
+          BUNDLER_VERSION: 2.0.1
           BUNDLE_JOBS: 3
           BUNDLE_RETRY: 3
           BUNDLE_PATH: vendor/bundle
@@ -16,6 +17,9 @@ jobs:
     steps:
       - checkout
       - run: mv config/database.yml.ci config/database.yml
+      - run:
+         name: Install Bundler 2.0.1
+         command: gem install bundler -v 2.0.1
       - restore_cache:
           keys:
             - el-bundle-v2-{{ checksum "Gemfile.lock" }}


### PR DESCRIPTION
Bundlerのバージョンを2.0.1系でbundle installしたことでciで動かなくなっていた。
こういう風に動くようになるはず。
https://circleci.com/gh/yumayo14/el-training/15#tests/containers/0