### PR TITLE
先を見据え、rubocop-performance を追加

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,3 +1,5 @@
+require: rubocop-performance
+
 LineLength:
   Max: 150
 

--- a/Gemfile
+++ b/Gemfile
@@ -48,6 +48,7 @@ group :development, :test do
   gem 'pry-rails'
   gem 'pry-byebug'
   gem 'rubocop', '~> 0.67.2', require: false
+  gem 'rubocop-performance'
   gem 'database_rewinder'
 end
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -217,6 +217,8 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (>= 1.4.0, < 1.6)
+    rubocop-performance (1.1.0)
+      rubocop (>= 0.67.0)
     ruby-progressbar (1.10.0)
     ruby_dep (1.5.0)
     rubyzip (1.2.2)
@@ -305,6 +307,7 @@ DEPENDENCIES
   rails-controller-testing
   rspec-rails
   rubocop (~> 0.67.2)
+  rubocop-performance
   sass-rails (~> 5.0)
   selenium-webdriver (>= 3.1.0)
   slim-rails (~> 3.1, >= 3.1.1)


### PR DESCRIPTION
## やったこと
- rubocopのver 0.6.8以降、Performance Cops が使えなくなるので、その際に Performance Copsの機能を使える様に設定


 