### PR TITLE
refactor: Factorybotがレシーバーになるメソッドの呼び出し方を変更

### DIFF
--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -26,6 +26,46 @@ RSpec.describe Task, type: :model do
       it { is_expected.to eq false }
     end
   end
+  describe 'Taskのenum' do
+    describe '正しい値が入っている場合' do
+      subject { build(:task, title: 'test', importance: importance, status: status) }
+      context '両方に正しい文字列が入っている場合' do
+        let(:importance) { '低' }
+        let(:status) { '完了' }
+        it { is_expected.to be_valid }
+      end
+      context '両方に正しい数字が入っている場合' do
+        let(:importance) { 2 }
+        let(:status) { 0 }
+        it { is_expected.to be_valid }
+      end
+    end
+    describe '正しくない値が入っている場合' do
+      subject { Proc.new { build(:task, title: 'test', importance: importance, status: status) } }
+      context 'importanceの値が異常な場合' do
+        let(:status) { '未着手' }
+        context 'importanceに異常な文字が入っている場合' do
+          let(:importance) { 'hoge' }
+          it { is_expected.to raise_error(ArgumentError) }
+        end
+        context 'importanceに異常な数字が入っている場合' do
+          let(:importance) { 3 }
+          it { is_expected.to raise_error(ArgumentError) }
+        end
+      end
+      context 'statusの値が異常な場合' do
+        let(:importance) { '低' }
+        context 'statusに異常な文字が入っている場合' do
+          let(:status) { 'hoge' }
+          it { is_expected.to raise_error(ArgumentError) }
+        end
+        context 'statusに異常な文字が入っている場合' do
+          let(:status) { 3 }
+          it { is_expected.to raise_error(ArgumentError) }
+        end
+      end
+    end
+  end
   describe 'Taskのscope' do
     let!(:task1) { create(:task, title: 'matched_task', status: '着手') }
     let!(:task2) { create(:task, title: 'matching', status: '着手') }

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -6,37 +6,37 @@ RSpec.describe Task, type: :model do
   describe 'Taskのバリデーション' do
     context 'titleが30文字以内で入力されている場合' do
       it '保存できる' do
-        task = FactoryBot.build(:task)
+        task = build(:task)
         expect(task.valid?).to eq true
       end
     end
     context 'titleの値がnilの場合' do
       it '保存できない' do
-        task = FactoryBot.build(:task, title: nil)
+        task = build(:task, title: nil)
         expect(task.valid?).to eq false
       end
     end
     context 'titleが30文字以上の場合' do
       it '保存できない' do
-        task = FactoryBot.build(:task, title: '12345678910/12345678910/12345678910')
+        task = build(:task, title: '12345678910/12345678910/12345678910')
         expect(task.valid?).to eq false
       end
     end
     context 'importanceが(低, 中, 高)以外の場合' do
       it '作成できない' do
-        expect { FactoryBot.build(:task, importance: 'sasa') }.to raise_error(ArgumentError)
-        expect { FactoryBot.build(:task, importance: 99) }.to raise_error(ArgumentError)
+        expect { build(:task, importance: 'sasa') }.to raise_error(ArgumentError)
+        expect { build(:task, importance: 99) }.to raise_error(ArgumentError)
       end
     end
     context 'statusが(未着手, 着手, 完了)以外の場合' do
       it '作成できない' do
-        expect { FactoryBot.build(:task, status: 'sasa') }.to raise_error(ArgumentError)
-        expect { FactoryBot.build(:task, status: 99) }.to raise_error(ArgumentError)
+        expect { build(:task, status: 'sasa') }.to raise_error(ArgumentError)
+        expect { build(:task, status: 99) }.to raise_error(ArgumentError)
       end
     end
     context '期限が過去の日付の場合' do
       it '作成できない' do
-        task = FactoryBot.build(:task, dead_line_on: '2008-09-25')
+        task = build(:task, dead_line_on: '2008-09-25')
         expect(task.valid?).to eq false
       end
     end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -41,27 +41,27 @@ RSpec.describe Task, type: :model do
       end
     end
     describe '正しくない値が入っている場合' do
-      subject { Proc.new { build(:task, title: 'test', importance: importance, status: status) } }
+      subject { build(:task, title: 'test', importance: importance, status: status) }
       context 'importanceの値が異常な場合' do
         let(:status) { '未着手' }
         context 'importanceに異常な文字が入っている場合' do
           let(:importance) { 'hoge' }
-          it { is_expected.to raise_error(ArgumentError) }
+          it { is_expected_block.to raise_error(ArgumentError) }
         end
         context 'importanceに異常な数字が入っている場合' do
           let(:importance) { 3 }
-          it { is_expected.to raise_error(ArgumentError) }
+          it { is_expected_block.to raise_error(ArgumentError) }
         end
       end
       context 'statusの値が異常な場合' do
         let(:importance) { '低' }
         context 'statusに異常な文字が入っている場合' do
           let(:status) { 'hoge' }
-          it { is_expected.to raise_error(ArgumentError) }
+          it { is_expected_block.to raise_error(ArgumentError) }
         end
         context 'statusに異常な文字が入っている場合' do
           let(:status) { 3 }
-          it { is_expected.to raise_error(ArgumentError) }
+          it { is_expected_block.to raise_error(ArgumentError) }
         end
       end
     end

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -4,41 +4,26 @@ require 'rails_helper'
 
 RSpec.describe Task, type: :model do
   describe 'Taskのバリデーション' do
+    let(:task) { build(:task, title: title, importance: importance, status: status, dead_line_on: dead_line_on) }
+    let(:title) { 'test' }
+    let(:importance) { '低' }
+    let(:status) { '未着手' }
+    let(:dead_line_on) { nil }
+    subject { task.valid? }
     context 'titleが30文字以内で入力されている場合' do
-      it '保存できる' do
-        task = build(:task)
-        expect(task.valid?).to eq true
-      end
+      it { is_expected.to eq true }
     end
     context 'titleの値がnilの場合' do
-      it '保存できない' do
-        task = build(:task, title: nil)
-        expect(task.valid?).to eq false
-      end
+      let(:title) { nil }
+      it { is_expected.to eq false }
     end
     context 'titleが30文字以上の場合' do
-      it '保存できない' do
-        task = build(:task, title: '12345678910/12345678910/12345678910')
-        expect(task.valid?).to eq false
-      end
-    end
-    context 'importanceが(低, 中, 高)以外の場合' do
-      it '作成できない' do
-        expect { build(:task, importance: 'sasa') }.to raise_error(ArgumentError)
-        expect { build(:task, importance: 99) }.to raise_error(ArgumentError)
-      end
-    end
-    context 'statusが(未着手, 着手, 完了)以外の場合' do
-      it '作成できない' do
-        expect { build(:task, status: 'sasa') }.to raise_error(ArgumentError)
-        expect { build(:task, status: 99) }.to raise_error(ArgumentError)
-      end
+      let(:title) { '12345678910/12345678910/12345678910' }
+      it { is_expected.to eq false }
     end
     context '期限が過去の日付の場合' do
-      it '作成できない' do
-        task = build(:task, dead_line_on: '2008-09-25')
-        expect(task.valid?).to eq false
-      end
+      let(:dead_line_on) { '2008-09-25' }
+      it { is_expected.to eq false }
     end
   end
   describe 'Taskのscope' do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -16,6 +16,7 @@
 #
 # See http://rubydoc.info/gems/rspec-core/RSpec/Core/Configuration
 require 'factory_bot'
+require 'support/rspec_module'
 RSpec.configure do |config|
   # rspec-expectations config goes here. You can use an alternate
   # assertion/expectation library such as wrong or the stdlib/minitest
@@ -104,4 +105,7 @@ RSpec.configure do |config|
   # Kernel.srand config.seed
 
   config.include FactoryBot::Syntax::Methods
+
+  # subjectにブロックを渡す際に用いるモジュールをインクルード
+  config.include IsExpectedBlock
 end

--- a/spec/support/rspec_module.rb
+++ b/spec/support/rspec_module.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+module IsExpectedBlock
+  def is_expected_block
+    expect { subject }
+  end
+end


### PR DESCRIPTION
## Isuue番号
#47 

## やったこと
- spec/models 内でも[FactoryBot.] の記述を省略
- spec/modelsのリファクタリング
- subjectにブロックを渡せるようにするメソッドを追加