### PR TITLE
enumでバインドする文字列を英語に変更

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -1,12 +1,12 @@
 # frozen_string_literal: true
 
 class Task < ApplicationRecord
-  enum importance: { 低: 0, 中: 1, 高: 2 }
-  enum status: { 未着手: 0, 着手: 1, 完了: 2 }
+  enum importance: { low: 0, middle: 1, high: 2 }
+  enum status: { not_started: 0, working: 1, completed: 2 }
 
   validates :title, presence: true, length: { maximum: 30 }
-  validates :importance, inclusion: { in: %w(低 中 高) }
-  validates :status, inclusion: { in: %w(未着手 着手 完了) }
+  validates :importance, inclusion: { in: %w(low middle high) }
+  validates :status, inclusion: { in: %w(not_started working completed) }
   validate :dead_line_on_cannot_be_in_the_past
 
   scope :orderd_by, ->(sort) { order(created_at: sort) }

--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -14,6 +14,14 @@ class Task < ApplicationRecord
   scope :by_status, ->(status) { where(status: status) }
   scope :search, ->(title, status) { by_title(title).by_status(status) }
 
+  def self.human_attribute_enum_value(attr_name, value)
+    human_attribute_name("#{attr_name}.#{value}")
+  end
+
+  def human_attribute_enum(attr_name)
+    self.class.human_attribute_enum_value(attr_name, self[attr_name])
+  end
+
   def dead_line_on_cannot_be_in_the_past
     errors.add(:dead_line_on, 'に過去の日付は使用できません') if dead_line_on.present? && dead_line_on < Date.today
   end

--- a/app/views/api/tasks/index.json.jbuilder
+++ b/app/views/api/tasks/index.json.jbuilder
@@ -12,12 +12,12 @@ json.nested do
       json.id task.id
       json.title task.title
       json.importance do
-        json.text task.importance
+        json.text task.human_attribute_enum(:importance)
         json.rank task.importance_before_type_cast
       end
       json.dead_line_on task.dead_line_on
       json.status do
-        json.text task.status
+        json.text task.human_attribute_enum(:status)
         json.num task.status_before_type_cast
       end
       json.detail task.detail

--- a/app/views/tasks/_task_form.slim
+++ b/app/views/tasks/_task_form.slim
@@ -8,13 +8,13 @@
     = f.text_field :title, class: "form-control", placeholder: "タイトル"
   .importance_block.form-group
     = f.label :importance
-    = f.select :importance, Task.importances.keys.to_a, {}
+    = f.select :importance, Task.importances.keys.map{ |k| [Task.human_attribute_enum_value('importance', k), k] }
   .dead_line_on_block.form-group
     = f.label :dead_line_on
     = f.date_select :dead_line_on
   .status_block.form-group
     = f.label :status
-    = f.select :status, Task.statuses.keys.to_a, {}
+    = f.select :status, Task.statuses.keys.map{ |k| [Task.human_attribute_enum_value('status', k), k] }
   .detail_block.form-group
     = f.label :detail
     = f.text_area :detail, class: "form-control", placeholder: "説明文"

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -21,9 +21,9 @@
             .status
               select v-model="selectedStatus" name="status" id="search_status"
                 option value='' 選択しない
-                option value="0" 未着手
-                option value="1" 着手
-                option value="2" 完了
+                option value="0" not_started
+                option value="1" working
+                option value="2" completed
           .submit
             button v-on:click="search" 検索
             button v-on:click="reset" 検索条件をリセット

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -21,9 +21,9 @@
             .status
               select v-model="selectedStatus" name="status" id="search_status"
                 option value='' 選択しない
-                option value="0" not_started
-                option value="1" working
-                option value="2" completed
+                option value="0" = t("actionview.task.index.status_value.not_started")
+                option value="1" = t("actionview.task.index.status_value.working")
+                option value="2" = t("actionview.task.index.status_value.completed")
           .submit
             button v-on:click="search" 検索
             button v-on:click="reset" 検索条件をリセット

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -9,6 +9,14 @@ ja:
         dead_line_on: 期限
         status: 状態
         detail: 説明文
+      task/importance:
+        low: "低"
+        middle: "中"
+        high: "高"
+      task/status:
+        not_started: "未着手"
+        working: "着手"
+        completed: "完了"
   actionview:
     task:
       index:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -22,8 +22,16 @@ ja:
       index:
         title: タイトル
         importance: 優先順位
+        importance_value:
+          low: 低
+          middle: 中
+          high: 高
         dead_line_on: 期限
         status: 状態
+        status_value:
+          not_started: 未着手
+          working: 着手
+          completed: 完了
         detail: 説明文
         created_at_day: 作成日
         link: 個別リンク

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -6,8 +6,8 @@ RSpec.describe Task, type: :model do
   describe 'Taskのバリデーション' do
     let(:task) { build(:task, title: title, importance: importance, status: status, dead_line_on: dead_line_on) }
     let(:title) { 'test' }
-    let(:importance) { '低' }
-    let(:status) { '未着手' }
+    let(:importance) { 'low' }
+    let(:status) { 'not_started' }
     let(:dead_line_on) { nil }
     subject { task.valid? }
     context 'titleが30文字以内で入力されている場合' do
@@ -30,8 +30,8 @@ RSpec.describe Task, type: :model do
     describe '正しい値が入っている場合' do
       subject { build(:task, title: 'test', importance: importance, status: status) }
       context '両方に正しい文字列が入っている場合' do
-        let(:importance) { '低' }
-        let(:status) { '完了' }
+        let(:importance) { 'low' }
+        let(:status) { 'completed' }
         it { is_expected.to be_valid }
       end
       context '両方に正しい数字が入っている場合' do
@@ -43,7 +43,7 @@ RSpec.describe Task, type: :model do
     describe '正しくない値が入っている場合' do
       subject { build(:task, title: 'test', importance: importance, status: status) }
       context 'importanceの値が異常な場合' do
-        let(:status) { '未着手' }
+        let(:status) { 'not_started' }
         context 'importanceに異常な文字が入っている場合' do
           let(:importance) { 'hoge' }
           it { is_expected_block.to raise_error(ArgumentError) }
@@ -54,7 +54,7 @@ RSpec.describe Task, type: :model do
         end
       end
       context 'statusの値が異常な場合' do
-        let(:importance) { '低' }
+        let(:importance) { 'low' }
         context 'statusに異常な文字が入っている場合' do
           let(:status) { 'hoge' }
           it { is_expected_block.to raise_error(ArgumentError) }
@@ -67,11 +67,11 @@ RSpec.describe Task, type: :model do
     end
   end
   describe 'Taskのscope' do
-    let!(:task1) { create(:task, title: 'matched_task', status: '着手') }
-    let!(:task2) { create(:task, title: 'matching', status: '着手') }
-    let!(:task3) { create(:task, title: 'hoge_fuga', status: '完了') }
+    let!(:task1) { create(:task, title: 'matched_task', status: 'working') }
+    let!(:task2) { create(:task, title: 'matching', status: 'working') }
+    let!(:task3) { create(:task, title: 'hoge_fuga', status: 'completed') }
     let(:search_query) { '' }
-    let(:selected_status) { '未着手' }
+    let(:selected_status) { 'not_started' }
     describe 'by_title' do
       subject { Task.by_title(search_query).map(&:id) }
       context '検索クエリが入力されていない場合' do
@@ -99,11 +99,11 @@ RSpec.describe Task, type: :model do
       end
       context 'ステータスで絞り込む場合' do
         context '選択したステータスと同じステータスのタスクがある場合' do
-          let(:selected_status) { '着手' }
+          let(:selected_status) { 'working' }
           it { is_expected.to contain_exactly(task1.id, task2.id) }
         end
         context '選択したステータスと同じステータスのタスクがない場合' do
-          let(:selected_status) { '未着手' }
+          let(:selected_status) { 'not_started' }
           it { is_expected.to be_empty }
         end
       end
@@ -113,12 +113,12 @@ RSpec.describe Task, type: :model do
       context 'クエリとステータスの両方で絞り込む場合' do
         context 'クエリとタイトルが一致し、ステータスが同じする場合' do
           let(:search_query) { 'match' }
-          let(:selected_status) { '着手' }
+          let(:selected_status) { 'working' }
           it { is_expected.to contain_exactly(task1.id, task2.id) }
         end
         context 'クエリとタイトルは一致するが、ステータスが異なる場合' do
           let(:search_query) { 'match' }
-          let(:selected_status) { '完了' }
+          let(:selected_status) { 'completed' }
           it { is_expected.to be_empty }
         end
       end
@@ -127,7 +127,7 @@ RSpec.describe Task, type: :model do
           it 'クエリとタイトルが一致するタスクの一覧が返ってくる'
         end
         context 'ステータスのみで絞り込む場合' do
-          let(:selected_status) { '完了' }
+          let(:selected_status) { 'completed' }
           it { is_expected.to contain_exactly(task3.id) }
         end
       end


### PR DESCRIPTION
## 対応するissue
close #61 

## やったこと
- enumでバインドしている文字列の値を英語に修正
- enum型の日本語訳を参照するメソッドをTaskモデルに追加
    参考ページ: https://qiita.com/daichirata/items/9495e2548417a4507fec