### PR TITLE
ステータス検索のフォームで「選択しない」を選んだ場合、ステータスでの絞り込みをしないように変更

### DIFF
--- a/app/models/task.rb
+++ b/app/models/task.rb
@@ -11,7 +11,7 @@ class Task < ApplicationRecord
 
   scope :orderd_by, ->(sort) { order(created_at: sort) }
   scope :by_title, ->(title) { where('title LIKE(?)', "%#{sanitize_sql_like(title)}%") }
-  scope :by_status, ->(status) { where(status: status) }
+  scope :by_status, ->(status) { where(status: status) if status.present? }
   scope :search, ->(title, status) { by_title(title).by_status(status) }
 
   def self.human_attribute_enum_value(attr_name, value)

--- a/spec/models/task_spec.rb
+++ b/spec/models/task_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Task, type: :model do
     let!(:task2) { create(:task, title: 'matching', status: 'working') }
     let!(:task3) { create(:task, title: 'hoge_fuga', status: 'completed') }
     let(:search_query) { '' }
-    let(:selected_status) { 'not_started' }
+    let(:selected_status) { '' }
     describe 'by_title' do
       subject { Task.by_title(search_query).map(&:id) }
       context '検索クエリが入力されていない場合' do
@@ -95,7 +95,7 @@ RSpec.describe Task, type: :model do
     describe 'by_status' do
       subject { Task.by_status(selected_status).map(&:id) }
       context 'ステータスで絞り込まない場合' do
-        it '全てのタスクが返ってくる'
+        it { is_expected.to contain_exactly(task1.id, task2.id, task3.id) }
       end
       context 'ステータスで絞り込む場合' do
         context '選択したステータスと同じステータスのタスクがある場合' do
@@ -124,7 +124,8 @@ RSpec.describe Task, type: :model do
       end
       context 'どちらか片方で絞り込む場合' do
         context 'クエリのみで絞り込む場合' do
-          it 'クエリとタイトルが一致するタスクの一覧が返ってくる'
+          let(:search_query) { 'match' }
+          it { is_expected.to contain_exactly(task1.id, task2.id) }
         end
         context 'ステータスのみで絞り込む場合' do
           let(:selected_status) { 'completed' }


### PR DESCRIPTION
## やったこと
- タスクの検索時、「選択しない」を選んだ場合、ステータスでの絞り込みを行わないように変更
  - by_statusスコープの中で、空文字列が引数にきた場合は検索しないように設定

## 補足
- guard clauseを書かなくても、scopeの場合、nilではなく呼び出しもとのActiveRecordRelationwo
返すので、後置if で記述。
- 参考資料 https://railsguides.jp/active_record_querying.html#%E6%9D%A1%E4%BB%B6%E6%96%87%E3%82%92%E4%BD%BF%E3%81%86

close #57 