### PR TITLE
style: タスク投稿画面の白余白が消える様にする

### DIFF
--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -11,3 +11,11 @@
 
 .winter {
 }
+
+.page_title_box {
+  padding: 20px 0;
+  .page_title {
+    margin: 0;
+    color: rgb(146, 64, 93);
+  }
+}

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,5 +1,6 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
+@import "common";
 @import "tasks";
 @import "form";
 @import "sakura";

--- a/app/views/tasks/edit.html.slim
+++ b/app/views/tasks/edit.html.slim
@@ -1,3 +1,4 @@
-h1 タスクの編集
+.page_title_box
+  h1.page_title タスクの編集
 .edit_task_form
   = render partial: "task_form", locals: { task: @task }

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -1,3 +1,4 @@
-h1 タスクの追加
+.page_title_box
+  h1.page_title タスクの追加
 .new_task_form
   = render partial: "task_form", locals: { task: @task }

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -1,5 +1,5 @@
-h1 タスクの詳細
-
+.page_title_box
+  h1.page_title タスクの詳細
 .task
   .task_head
     p #{@task.title} #{@task.importance} #{@task.status} #{@task.dead_line_on}


### PR DESCRIPTION
## やったこと
before
<img width="1437" alt="スクリーンショット 2019-05-16 18 09 47" src="https://user-images.githubusercontent.com/31206922/57841606-d5e16980-7805-11e9-969e-64f30b6b6c56.png">


after
<img width="1439" alt="スクリーンショット 2019-05-16 18 08 25" src="https://user-images.githubusercontent.com/31206922/57841529-ad596f80-7805-11e9-8aa5-e7e3b0b05a0d.png">


## 補足
-  https://github.com/yumayo14/el-training/pull/86 の https://github.com/yumayo14/el-training/pull/86/commits/efede82dd38080cc600fa6a0aed4bcc4707d2d91 コミットに、このPRの修正内容の一部が含まれてしまったので、そちらも確認いただけると幸いです。

close #70 
