### PR TITLE
フラッシュメッセージにbootstrapが適用される様に修正

### DIFF
--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -1,0 +1,4 @@
+.spring {
+  background: #f9f1f4;
+  color: rgb(146,64,93);
+}

--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -1,5 +1,5 @@
 .spring {
-  background: #f9f1f4;
+  background: rgb(249,241,244);
   color: rgb(146,64,93);
 }
 

--- a/app/assets/stylesheets/_common.scss
+++ b/app/assets/stylesheets/_common.scss
@@ -2,3 +2,12 @@
   background: #f9f1f4;
   color: rgb(146,64,93);
 }
+
+.summer {
+}
+
+.fall {
+}
+
+.winter {
+}

--- a/app/assets/stylesheets/_new.scss
+++ b/app/assets/stylesheets/_new.scss
@@ -1,6 +1,0 @@
-.spring {
-  background: #f9f1f4;
-  h1 {
-    color: rgb(146,64,93);
-  }
-}

--- a/app/assets/stylesheets/_tasks.scss
+++ b/app/assets/stylesheets/_tasks.scss
@@ -2,11 +2,9 @@
 // They will automatically be included in application.css.
 // You can use Sass (SCSS) here: http://sass-lang.com/
 
-.spring {
+.menu {
   width: 100vw;
   height:calc(100vh - 50px);
-  background: #f9f1f4;
-  color: rgb(146,64,93);
   button {
     padding: 2px !important;
     background-color: rgba(255, 102, 204, 0.2) !important;

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,11 +1,11 @@
 @import "bootstrap-sprockets";
 @import "bootstrap";
 @import "tasks";
-@import "new";
 @import "form";
 @import "sakura";
 @import "animation/flake";
 @import "animation/delayed_flake";
+@import "common";
 
 html, body {
   //重要じゃないやつで高さを調整する

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -18,23 +18,28 @@ class TasksController < ApplicationController
   def create
     @task = User.first.tasks.new(task_params)
     if @task.save
-      redirect_to tasks_path, notice: '新しいタスクが作成されました'
+      flash[:success] = '新しいタスクが作成されました'
+      redirect_to tasks_path
     else
+      flash.now[:danger] = 'タスクの作成に失敗しました'
       render :new
     end
   end
 
   def update
     if @task.update(task_params)
-      redirect_to tasks_path, notice: 'タスクの内容が変更されました'
+      flash[:success] = 'タスクの内容が更新されました'
+      redirect_to tasks_path
     else
+      flash.now[:danger] = 'タスクの更新に失敗しました'
       render :edit
     end
   end
 
   def destroy
     @task.destroy
-    redirect_to tasks_path, notice: 'タスクを削除しました'
+    flash[:success] = 'タスクを削除しました'
+    redirect_to tasks_path
   end
 
   private

--- a/app/helpers/view_helper.rb
+++ b/app/helpers/view_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module ViewHelper
+  def formatted_flash(flash)
+    flash. each do |key, value|
+      concat content_tag :div, value, class: "alert alert-#{key}"
+    end
+  end
+end

--- a/app/views/layouts/_flash.slim
+++ b/app/views/layouts/_flash.slim
@@ -1,0 +1,1 @@
+- formatted_flash(flash)

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -17,5 +17,5 @@ html
         li.nav-item
           = link_to "タスクの投稿", new_task_path, class: "nav-link"
     .spring
-      = render partial: "layouts/flash", locals: { flash: flash }
+      = render partial: "layouts/flash", locals: { flash: flash } if flash.present?
       = yield

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -16,7 +16,6 @@ html
           = link_to "タスク一覧", tasks_path, class: "nav-link"
         li.nav-item
           = link_to "タスクの投稿", new_task_path, class: "nav-link"
-    - flash.each do |key, value|
-      .alert.alert-#{key}
-        p = value
-    = yield
+    .spring
+      = render partial: "layouts/flash", locals: { flash: flash }
+      = yield

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -1,7 +1,7 @@
 / .sky
 /   = image_tag("summer_top.jpg", class: "summer")
 
-.spring#sakura
+.menu#sakura
   = render partial: "flask"
   .container
     #all_tasks

--- a/app/views/tasks/new.html.slim
+++ b/app/views/tasks/new.html.slim
@@ -1,4 +1,3 @@
-.spring
-  h1 タスクの追加
-  .new_task_form
-    = render partial: "task_form", locals: { task: @task }
+h1 タスクの追加
+.new_task_form
+  = render partial: "task_form", locals: { task: @task }

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -183,6 +183,7 @@ RSpec.feature'Tasks', type: :feature, js: true do
         click_button '登録する'
       end
       it '投稿に失敗する' do
+        expect(page).to have_content 'タスクの作成に失敗しました'
         expect(page).to have_content 'タイトルを入力してください'
       end
     end
@@ -199,6 +200,7 @@ RSpec.feature'Tasks', type: :feature, js: true do
         click_button '登録する'
       end
       it '投稿に失敗する' do
+        expect(page).to have_content 'タスクの作成に失敗しました'
         expect(page).to have_content 'タイトルは30文字以内で入力してください'
       end
     end
@@ -215,6 +217,7 @@ RSpec.feature'Tasks', type: :feature, js: true do
         click_button '登録する'
       end
       it '投稿に失敗する' do
+        expect(page).to have_content 'タスクの作成に失敗しました'
         expect(page).to have_content '期限に過去の日付は使用できません'
       end
     end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -260,7 +260,7 @@ RSpec.feature'Tasks', type: :feature, js: true do
           click_button '更新する'
         end
         it '作成したタスクの更新する' do
-          expect(page).to have_content 'タスクの内容が変更されました'
+          expect(page).to have_content 'タスクの内容が更新されました'
         end
       end
     end


### PR DESCRIPTION
before
![スクリーンショット 2019-05-17 11 28 16](https://user-images.githubusercontent.com/31206922/57901851-a41de080-78a1-11e9-9ded-08c0ebc72791.png)

after
<img width="1440" alt="スクリーンショット 2019-05-17 12 03 20" src="https://user-images.githubusercontent.com/31206922/57901862-af710c00-78a1-11e9-8766-a45666d9cd59.png">

<img width="1440" alt="スクリーンショット 2019-05-20 9 37 07" src="https://user-images.githubusercontent.com/31206922/57990710-2990d300-7ae4-11e9-92d6-1e777083e3e0.png">
