### PR TITLE
DBに暗号化されたパスワードが保存される様に変更

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -25,6 +25,10 @@ class User < ApplicationRecord
   private
 
   def hash_password
-    self.hashed_password = Digest::SHA256.hexdigest hashed_password
+    self.hashed_password = Digest::SHA256.hexdigest(set_salt + hashed_password)
+  end
+
+  def set_salt
+    self.salt ||= SecureRandom.hex(8)
   end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,6 +20,7 @@ class User < ApplicationRecord
   validates :name, presence: true, length: { maximum: 20 }
   validates :accountid, presence: true, length: { maximum: 15 }, uniqueness: true
   validates :hashed_password, presence: true, length: { minimum: 8 }
+  validates :salt, presence: true, uniqueness: true, on: :update
 
   private
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -15,7 +15,15 @@
 class User < ApplicationRecord
   has_many :tasks, dependent: :destroy
 
+  before_save :hash_password
+
   validates :name, presence: true, length: { maximum: 20 }
   validates :accountid, presence: true, length: { maximum: 15 }, uniqueness: true
-  validates :password, presence: true, length: { minimum: 8 }
+  validates :hashed_password, presence: true, length: { minimum: 8 }
+
+  private
+
+  def hash_password
+    self.hashed_password = Digest::SHA256.hexdigest hashed_password
+  end
 end

--- a/db/migrate/20190520055501_change_users_password_column_to_hashed_password_column.rb
+++ b/db/migrate/20190520055501_change_users_password_column_to_hashed_password_column.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class ChangeUsersPasswordColumnToHashedPasswordColumn < ActiveRecord::Migration[5.2]
+  def change
+    rename_column :users, :password, :hashed_password
+  end
+end

--- a/db/migrate/20190520082836_change_hashed_password_column_comment.rb
+++ b/db/migrate/20190520082836_change_hashed_password_column_comment.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class ChangeHashedPasswordColumnComment < ActiveRecord::Migration[5.2]
+  def up
+    change_column :users, :hashed_password, :string, null: false, comment: 'ハッシュ化されたユーザーのパスワード'
+  end
+
+  def down
+    change_column :users, :hashed_password, :string, null: false, comment: 'ユーザーのパスワード'
+  end
+end

--- a/db/migrate/20190521044403_add_salt_column_to_users.rb
+++ b/db/migrate/20190521044403_add_salt_column_to_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddSaltColumnToUsers < ActiveRecord::Migration[5.2]
+  def change
+    add_column :users, :salt, :string, null: false, unique: true, comment: 'パスワードハッシュ化の際に用いるデータ'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_16_065009) do
+ActiveRecord::Schema.define(version: 2019_05_20_082836) do
   create_table 'tasks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
     t.bigint 'user_id', comment: 'タスクを投稿したユーザーのidと紐づけられる。投稿したユーザーが削除された場合、そのユーザーが投稿したタスクも削除される'
     t.string 'title', null: false, comment: 'タスク名'
@@ -30,9 +30,9 @@ ActiveRecord::Schema.define(version: 2019_05_16_065009) do
   create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
     t.string 'name', null: false, comment: 'ユーザーの本名'
     t.string 'accountid', default: '0', null: false, comment: 'ユーザーのアカウントID、ユーザー固有の値'
-    t.string 'password', null: false, comment: 'ユーザーのパスワード'
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
+    t.string 'hashed_password', null: false, comment: 'ハッシュ化されたユーザーのパスワード'
   end
 
   add_foreign_key 'tasks', 'users'

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_05_20_082836) do
+ActiveRecord::Schema.define(version: 2019_05_21_044403) do
   create_table 'tasks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
     t.bigint 'user_id', comment: 'タスクを投稿したユーザーのidと紐づけられる。投稿したユーザーが削除された場合、そのユーザーが投稿したタスクも削除される'
     t.string 'title', null: false, comment: 'タスク名'
@@ -33,6 +33,7 @@ ActiveRecord::Schema.define(version: 2019_05_20_082836) do
     t.datetime 'created_at', null: false
     t.datetime 'updated_at', null: false
     t.string 'hashed_password', null: false, comment: 'ハッシュ化されたユーザーのパスワード'
+    t.string 'salt', null: false, comment: 'パスワードハッシュ化の際に用いるデータ'
   end
 
   add_foreign_key 'tasks', 'users'

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -17,5 +17,6 @@ FactoryBot.define do
     name { Faker::Name.name }
     accountid { Faker::Internet.unique.username(1..15) }
     hashed_password { Faker::Internet.password }
+    salt {}
   end
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -16,6 +16,6 @@ FactoryBot.define do
   factory :user do
     name { Faker::Name.name }
     accountid { Faker::Internet.unique.username(1..15) }
-    password { Faker::Internet.password }
+    hashed_password { Faker::Internet.password }
   end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -60,4 +60,12 @@ RSpec.describe User, type: :model do
       it { is_expected.to eq false }
     end
   end
+  describe 'パスワードの暗号化' do
+    let!(:user) { create(:user, hashed_password: hashed_password) }
+    let(:hashed_password) { 'morethan8' }
+    describe '平文を含まない様に暗号化している' do
+      subject { user.hashed_password }
+      it { is_expected.not_to include hashed_password }
+    end
+  end
 end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -15,7 +15,7 @@
 require 'rails_helper'
 
 RSpec.describe User, type: :model do
-  describe 'Userのバリデーション' do
+  describe 'バリデーション' do
     let(:user) { build(:user, name: name, accountid: accountid, hashed_password: hashed_password) }
     let(:name) { '田中 太郎' }
     let(:accountid) { 'tanatarou' }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,10 +16,10 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   describe 'Userのバリデーション' do
-    let(:user) { build(:user, name: name, accountid: accountid, password: password) }
+    let(:user) { build(:user, name: name, accountid: accountid, hashed_password: hashed_password) }
     let(:name) { '田中 太郎' }
     let(:accountid) { 'tanatarou' }
-    let(:password) { 'morethan8' }
+    let(:hashed_password) { 'morethan8' }
     subject { user.valid? }
     context '名前が20文字以内の場合' do
       it { is_expected.to eq true }
@@ -44,7 +44,7 @@ RSpec.describe User, type: :model do
       it { is_expected.to eq false }
     end
     context '既存のユーザーと同じアカウントIDで登録しようとした場合' do
-      let!(:same_accountid_user) { create(:user, name: '田中 宏和', accountid: 'tanahiro', password: 'morethan8') }
+      let!(:same_accountid_user) { create(:user, name: '田中 宏和', accountid: 'tanahiro', hashed_password: 'morethan8') }
       let(:accountid) { 'tanahiro' }
       it { is_expected.to eq false }
     end
@@ -52,11 +52,11 @@ RSpec.describe User, type: :model do
       it { is_expected.to eq true }
     end
     context 'パスワードが入力されていない場合' do
-      let(:password) { nil }
+      let(:hashed_password) { nil }
       it { is_expected.to eq false }
     end
     context 'パスワードが8文字より少ない場合' do
-      let(:password) { '1a2b3c4' }
+      let(:hashed_password) { '1a2b3c4' }
       it { is_expected.to eq false }
     end
   end


### PR DESCRIPTION
## やったこと
- usersテーブルのカラム名をpasswordからhashed_passwordに変更
- ハッシュ化されたパスワードがDBに保存される様に修正（具体的な実装については後述）

## ハッシュ化について
- bcryptを用いず、rubyのOpenSSLライブラリを用いて実装。
  -  採用アルゴリズム: SHA256

## ソルトデータの付与について
- ソルトデータはランダムな16文字の文字列
- 暗号化前のパスワードの前にソルトデータを付けている

参考サイト
https://blog.ohgaki.net/password_hashing

https://qiita.com/chroju/items/3ddae568206b8bc3d8f9

https://www.slideshare.net/uji52/sha256-65740989

## 関連issue
#38 