### PR TITLE
rubocopとrspecが両方走るtaskを追加

### DIFF
--- a/lib/tasks/test.rake
+++ b/lib/tasks/test.rake
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+namespace :test do
+  desc 'rubocopとrspecを同時に走らせるタスク'
+  task :strict_mode do
+    sh 'bundle exec rubocop'
+    sh 'bundle exec rspec'
+  end
+end


### PR DESCRIPTION
いちいちrubocopとrspecを打つのが大変だったので、一つのコマンドで両方走るタスクを作成