### PR TITLE
ユーザーの更新時、勝手にhashed_passwordの値が書き換わるバグの修正

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -20,7 +20,7 @@ class User < ApplicationRecord
 
   validates :name, presence: true, length: { maximum: 20 }
   validates :accountid, presence: true, length: { maximum: 15 }, uniqueness: true
-  validates :password, presence: true, length: { minimum: 8 }, on: :create
+  validates :password, presence: true, length: { minimum: 8 }, on: :password_change
   validates :hashed_password, presence: true, on: :update
   validates :salt, presence: true, uniqueness: true, on: :update
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -13,14 +13,15 @@
 #
 
 class User < ApplicationRecord
-  attr_accessor :cookie_token
+  attr_accessor :password, :cookie_token
   has_many :tasks, dependent: :destroy
 
   before_save :set_hashed_password
 
   validates :name, presence: true, length: { maximum: 20 }
   validates :accountid, presence: true, length: { maximum: 15 }, uniqueness: true
-  validates :hashed_password, presence: true, length: { minimum: 8 }
+  validates :password, presence: true, length: { minimum: 8 }, on: :create
+  validates :hashed_password, presence: true, on: :update
   validates :salt, presence: true, uniqueness: true, on: :update
 
   def authenticated?(login_password)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -46,7 +46,9 @@ class User < ApplicationRecord
   end
 
   def set_hashed_password
-    self.hashed_password = hashing_with_salt(set_salt, hashed_password)
+    return hashed_password if password.nil?
+
+    self.hashed_password = hashing_with_salt(set_salt, password)
   end
 
   def set_salt

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -16,7 +16,8 @@ FactoryBot.define do
   factory :user do
     name { Faker::Name.name }
     accountid { Faker::Internet.unique.username(1..15) }
-    hashed_password { Faker::Internet.password }
+    password { Faker::Internet.password }
+    hashed_password {}
     hashed_cookie_token {}
     salt {}
   end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -65,7 +65,26 @@ RSpec.describe User, type: :model do
     let(:password) { 'morethan8' }
     describe '平文を含まない様に暗号化している' do
       subject { user.hashed_password }
-      it { is_expected.not_to include hashed_password }
+      it { is_expected.not_to include password }
+    end
+    context 'ユーザー情報が更新された場合' do
+      let!(:previous_hashed_password) { user.hashed_password }
+      context 'パスワードが更新された場合' do
+        let(:new_password) { 'newpassword' }
+        before { user.update(password: new_password) }
+        describe '新しいパスワードを暗号化したものが保存される' do
+          subject { user.hashed_password }
+          it { is_expected.not_to eq previous_hashed_password }
+        end
+      end
+      context 'パスワード以外の情報が更新された場合' do
+        let(:new_name) { 'newname' }
+        before { user.update(name: new_name) }
+        describe 'パスワード情報は更新されない' do
+          subject { user.hashed_password }
+          it { is_expected.to eq previous_hashed_password }
+        end
+      end
     end
   end
   describe 'メソッド' do

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -16,10 +16,10 @@ require 'rails_helper'
 
 RSpec.describe User, type: :model do
   describe 'バリデーション' do
-    let(:user) { build(:user, name: name, accountid: accountid, hashed_password: hashed_password) }
+    let(:user) { build(:user, name: name, accountid: accountid, password: password) }
     let(:name) { '田中 太郎' }
     let(:accountid) { 'tanatarou' }
-    let(:hashed_password) { 'morethan8' }
+    let(:password) { 'morethan8' }
     subject { user.valid? }
     context '名前が20文字以内の場合' do
       it { is_expected.to eq true }
@@ -44,7 +44,7 @@ RSpec.describe User, type: :model do
       it { is_expected.to eq false }
     end
     context '既存のユーザーと同じアカウントIDで登録しようとした場合' do
-      let!(:same_accountid_user) { create(:user, name: '田中 宏和', accountid: 'tanahiro', hashed_password: 'morethan8') }
+      let!(:same_accountid_user) { create(:user, name: '田中 宏和', accountid: 'tanahiro', password: 'morethan8') }
       let(:accountid) { 'tanahiro' }
       it { is_expected.to eq false }
     end
@@ -52,25 +52,25 @@ RSpec.describe User, type: :model do
       it { is_expected.to eq true }
     end
     context 'パスワードが入力されていない場合' do
-      let(:hashed_password) { nil }
+      let(:password) { nil }
       it { is_expected.to eq false }
     end
     context 'パスワードが8文字より少ない場合' do
-      let(:hashed_password) { '1a2b3c4' }
+      let(:password) { '1a2b3c4' }
       it { is_expected.to eq false }
     end
   end
   describe 'パスワードの暗号化' do
-    let!(:user) { create(:user, hashed_password: hashed_password) }
-    let(:hashed_password) { 'morethan8' }
+    let!(:user) { create(:user, password: password) }
+    let(:password) { 'morethan8' }
     describe '平文を含まない様に暗号化している' do
       subject { user.hashed_password }
       it { is_expected.not_to include hashed_password }
     end
   end
   describe 'メソッド' do
-    let!(:user) { create(:user, hashed_password: hashed_password) }
-    let(:hashed_password) { 'morethan8' }
+    let!(:user) { create(:user, password: password) }
+    let(:password) { 'morethan8' }
     describe '#authenticated?' do
       let(:login_password) { '' }
       subject { user.authenticated?(login_password) }

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe User, type: :model do
     let(:name) { '田中 太郎' }
     let(:accountid) { 'tanatarou' }
     let(:password) { 'morethan8' }
-    subject { user.valid? }
+    subject { user.valid?(:password_change) }
     context '名前が20文字以内の場合' do
       it { is_expected.to eq true }
     end
@@ -70,11 +70,16 @@ RSpec.describe User, type: :model do
     context 'ユーザー情報が更新された場合' do
       let!(:previous_hashed_password) { user.hashed_password }
       context 'パスワードが更新された場合' do
-        let(:new_password) { 'newpassword' }
-        before { user.update(password: new_password) }
-        describe '新しいパスワードを暗号化したものが保存される' do
-          subject { user.hashed_password }
-          it { is_expected.not_to eq previous_hashed_password }
+        before { user.password = new_password }
+        context '新しいパスワードが8文字より多い場合' do
+          let(:new_password) { 'newpassword' }
+          subject { user.save(context: :password_change) }
+          it { is_expected.to eq true }
+        end
+        context '新しいパスワードが8文字より少ない場合' do
+          let(:new_password) { 'new' }
+          subject { user.save(context: :password_change) }
+          it { is_expected.to eq false }
         end
       end
       context 'パスワード以外の情報が更新された場合' do

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -4,7 +4,7 @@ require 'rails_helper'
 
 RSpec.describe 'Session', type: :request do
   describe 'POST#create' do
-    let!(:user) { create(:user, name: 'Json', accountid: 'Iamtest', hashed_password: 'thisisTest') }
+    let!(:user) { create(:user, name: 'Json', accountid: 'Iamtest', password: 'thisisTest') }
     let!(:log_in) do
       post sessions_path, params: {
         session: {


### PR DESCRIPTION
## やったこと
- passwordという仮想属性を追加
- パスワード情報を更新しない場合、暗号化されたパスワード情報が書き変わらないようにguard clause を仕込む

## 該当する ssue
close #96 
