### PR TITLE
ログインしているユーザーのタスクのみが表示され、ログインしていない場合はログイン画面へ強制的に遷移される様にする

### DIFF
--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -14,6 +14,6 @@ parserOptions:
 plugins:
   - vue
 rules: {
-  indent: ["error", 2, {CallExpression: {arguments: "first"}}],
+  indent: ["error", 2, {CallExpression: {arguments: "first"}, "ObjectExpression": "first"}],
   max-len: ["error", { "code": 120 }]
 }

--- a/.eslintrc.yml
+++ b/.eslintrc.yml
@@ -15,5 +15,5 @@ plugins:
   - vue
 rules: {
   indent: ["error", 2, {CallExpression: {arguments: "first"}}],
-  max-len: ["error", { "code": 110 }]
+  max-len: ["error", { "code": 120 }]
 }

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -3,9 +3,15 @@
 class Api::TasksController < ApplicationController # rubocop:disable Style/ClassAndModuleChildren
   def index
     @tasks = if params[:title] || params[:status]
-               Task.search(params[:title], params[:status]).orderd_by(:desc).page(params[:page]).per(10)
+               login_user.tasks.search(params[:title], params[:status]).orderd_by(:desc).page(params[:page]).per(10)
              else
-               Task.all.orderd_by(:desc).page(params[:page]).per(10)
+               login_user.tasks.orderd_by(:desc).page(params[:page]).per(10)
              end
+  end
+
+  private
+
+  def login_user
+    User.find(cookies.signed[:user_id])
   end
 end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -1,17 +1,12 @@
 # frozen_string_literal: true
 
 class Api::TasksController < ApplicationController # rubocop:disable Style/ClassAndModuleChildren
+  include SessionsHelper
   def index
     @tasks = if params[:title] || params[:status]
-               login_user.tasks.search(params[:title], params[:status]).orderd_by(:desc).page(params[:page]).per(10)
+               current_user.tasks.search(params[:title], params[:status]).orderd_by(:desc).page(params[:page]).per(10)
              else
-               login_user.tasks.orderd_by(:desc).page(params[:page]).per(10)
+               current_user.tasks.orderd_by(:desc).page(params[:page]).per(10)
              end
-  end
-
-  private
-
-  def login_user
-    User.find(cookies.signed[:user_id])
   end
 end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,13 +3,7 @@
 class TasksController < ApplicationController
   before_action :set_task, only: %i(show edit update destroy)
 
-  # def index
-  #   @tasks = Task.order(created_at: 'DESC')
-  #   respond_to do |format|
-  #     format.html
-  #     format.json
-  #   end
-  # end
+  def index; end
 
   def new
     @task = User.first.tasks.new

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 class TasksController < ApplicationController
+  include SessionsHelper
   before_action :set_task, only: %i(show edit update destroy)
 
   def index; end

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -3,6 +3,7 @@
 class TasksController < ApplicationController
   include SessionsHelper
   before_action :set_task, only: %i(show edit update destroy)
+  before_action :require_login
 
   def index; end
 

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -14,4 +14,17 @@ module SessionsHelper
   def current_user
     User.find(cookies.signed[:user_id]) if cookies[:user_id].present?
   end
+
+  def logged_in?
+    return true if current_user.present?
+
+    false
+  end
+
+  def require_login
+    unless logged_in? # rubocop:disable Style/GuardClause
+      flash[:danger] = 'ログインを行なってください'
+      redirect_to login_path
+    end
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -10,4 +10,8 @@ module SessionsHelper
     cookies[:user_token] = { value: user.cookie_token, expires: 1.weeks.from_now }
     cookies.signed[:user_id] = { value: user.id, expires: 1.weeks.from_now }
   end
+
+  def current_user
+    User.find(cookies.signed[:user_id]) if cookies[:user_id].present?
+  end
 end

--- a/app/javascript/packs/modules/axios.js
+++ b/app/javascript/packs/modules/axios.js
@@ -2,14 +2,23 @@ import axios from 'axios';
 
 /**
  * 各リクエストの際、必要な設定をしたaxiosを返す関数。
+ * @param {boolean} withCsrf CSRFトークンを埋め込むかどうか
+ * @param {boolean} withCookie withCredentials オプションをtrueにするかどうか
  * @return {axios} CSRFトークンをリクエストヘッダに含めたaxiosを返す
  */
-function prepareAxios() {
-  return axios.create({
-    headers: {
+function prepareAxios(withCsrf, withCookie) {
+  let headersOption = {};
+
+  if (withCsrf) {
+    headersOption = {
       'X-Requested-With': 'XMLHttpRequest',
       'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
-    },
+    };
+  }
+
+  return axios.create({
+    headers: headersOption,
+    withCredentials: withCookie,
   });
 }
 

--- a/app/javascript/packs/modules/axios.js
+++ b/app/javascript/packs/modules/axios.js
@@ -2,9 +2,9 @@ import axios from 'axios';
 
 /**
  * 各リクエストの際、必要な設定をしたaxiosを返す関数。
- * @param {boolean} withCsrf CSRFトークンを埋め込むかどうか
- * @param {boolean} withCookie withCredentials オプションをtrueにするかどうか
- * @return {axios} CSRFトークンをリクエストヘッダに含めたaxiosを返す
+ * @param {object} settingParams withCsrf(CSRFトークンを埋め込むか)とwithCookie（withCredentialsオプションをtrueにするか）というキーで
+ *                               boolean型のデータが入っている
+ * @return {axios} settingParamsの値に応じて設定されたaxiosを返す
  */
 function prepareAxios(withCsrf, withCookie) {
   let headersOption = {};

--- a/app/javascript/packs/modules/axios.js
+++ b/app/javascript/packs/modules/axios.js
@@ -6,20 +6,18 @@ import axios from 'axios';
  *                               boolean型のデータが入っている
  * @return {axios} settingParamsの値に応じて設定されたaxiosを返す
  */
-function prepareAxios(withCsrf, withCookie) {
-  let headersOption = {};
+function prepareAxios(settingParams) {
+  const axiosConfiguration = {};
+  const headersOption = {'X-Requested-With': 'XMLHttpRequest'};
 
-  if (withCsrf) {
-    headersOption = {
-      'X-Requested-With': 'XMLHttpRequest',
-      'X-CSRF-TOKEN': document.querySelector('meta[name="csrf-token"]').getAttribute('content'),
-    };
+  if (settingParams['withCsrf']) {
+    headersOption['X-CSRF-TOKEN'] = document.querySelector('meta[name="csrf-token"]').getAttribute('content');
   }
 
-  return axios.create({
-    headers: headersOption,
-    withCredentials: withCookie,
-  });
+  axiosConfiguration['headers'] = headersOption;
+  axiosConfiguration['withCredentials'] = settingParams['withCookie'];
+
+  return axios.create(axiosConfiguration);
 }
 
 export default prepareAxios;

--- a/app/javascript/packs/sessions/sessions_vue.js
+++ b/app/javascript/packs/sessions/sessions_vue.js
@@ -12,8 +12,8 @@ window.loginForm = new Vue({
   },
   methods: {
     requestLogin: function() {
-      prepareAxios().post(this.login_url,
-                          new URLSearchParams({'accountid': this.accountid, 'password': this.password})
+      prepareAxios(true, false).post(this.login_url,
+                                     new URLSearchParams({'accountid': this.accountid, 'password': this.password})
       ).then(function(response) {
         window.location.href = response.data.redirect_url;
         toastr.success('ログインに成功しました。');

--- a/app/javascript/packs/sessions/sessions_vue.js
+++ b/app/javascript/packs/sessions/sessions_vue.js
@@ -12,8 +12,9 @@ window.loginForm = new Vue({
   },
   methods: {
     requestLogin: function() {
-      prepareAxios(true, false).post(this.login_url,
-                                     new URLSearchParams({'accountid': this.accountid, 'password': this.password})
+      prepareAxios({withCsrf: true, withCookie: false}).post(this.login_url,
+                                                             new URLSearchParams({'accountid': this.accountid,
+                                                                                  'password': this.password})
       ).then(function(response) {
         window.location.href = response.data.redirect_url;
         toastr.success('ログインに成功しました。');

--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -9,8 +9,7 @@ window.tasks = new Vue({
   el: '#all_tasks',
   data: {
     tasks: [],
-    resort_url: 'tasks.json',
-    resource_url: '/api/tasks.json',
+    resource_url: '/api/tasks',
     options: {
       remote_data: 'nested.data',
       remote_current_page: 'nested.current_page',

--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -1,9 +1,9 @@
 import Vue from 'vue';
-import axios from 'axios';
+import prepareAxios from '../modules/axios';
 import VuePaginator from 'vuejs-paginator';
 import _ from 'lodash';
 
-Vue.prototype.$http = axios;
+Vue.prototype.$http = prepareAxios(false, false);
 
 window.tasks = new Vue({
   el: '#all_tasks',
@@ -57,7 +57,7 @@ window.tasks = new Vue({
       );
     },
     search: function() {
-      axios.get(this.resource_url, {
+      prepareAxios(false, true).get(this.resource_url, {
         params: {
           title: this.searchQuery,
           status: this.selectedStatus,
@@ -69,7 +69,7 @@ window.tasks = new Vue({
       });
     },
     getTasks: function() {
-      axios.get(this.resource_url, {withCredentials: true}).then(function(response) {
+      prepareAxios(false, true).get(this.resource_url, {withCredentials: true}).then(function(response) {
         this.tasks = response.data.nested.data;
       }.bind(this)).catch(function(e) {
         alert(e);

--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -3,7 +3,7 @@ import prepareAxios from '../modules/axios';
 import VuePaginator from 'vuejs-paginator';
 import _ from 'lodash';
 
-Vue.prototype.$http = prepareAxios(false, false);
+Vue.prototype.$http = prepareAxios({withCsrf: false, withCookie: false});
 
 window.tasks = new Vue({
   el: '#all_tasks',
@@ -57,7 +57,7 @@ window.tasks = new Vue({
       );
     },
     search: function() {
-      prepareAxios(false, true).get(this.resource_url, {
+      prepareAxios({withCsrf: false, withCookie: true}).get(this.resource_url, {
         params: {
           title: this.searchQuery,
           status: this.selectedStatus,
@@ -69,7 +69,7 @@ window.tasks = new Vue({
       });
     },
     getTasks: function() {
-      prepareAxios(false, true).get(this.resource_url, {withCredentials: true}).then(function(response) {
+      prepareAxios({withCsrf: false, withCookie: true}).get(this.resource_url).then(function(response) {
         this.tasks = response.data.nested.data;
       }.bind(this)).catch(function(e) {
         alert(e);

--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -70,7 +70,7 @@ window.tasks = new Vue({
       });
     },
     getTasks: function() {
-      axios.get(this.resource_url).then(function(response) {
+      axios.get(this.resource_url, {withCredentials: true}).then(function(response) {
         this.tasks = response.data.nested.data;
       }.bind(this)).catch(function(e) {
         alert(e);

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,14 +3,14 @@
 Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
-  resources :tasks
   root to: 'tasks#index'
+  resources :tasks
 
   get 'login', to: 'sessions#new'
   post 'login', to: 'sessions#create'
   delete 'logout', to: 'sessions#destroy'
 
-  namespace :api do
+  namespace :api, format: 'json' do
     resources :tasks, only: [:index]
   end
 end

--- a/spec/factories/tasks.rb
+++ b/spec/factories/tasks.rb
@@ -17,11 +17,11 @@
 
 FactoryBot.define do
   factory :task do
+    user
     sequence(:title) { |n| "#{n}番目" }
     importance { 0 }
     sequence(:dead_line_on) { |n| "2020-07-#{n}" }
     status { 0 }
     detail { 'infinity_task...' }
-    user
   end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -2,7 +2,7 @@
 
 require 'rails_helper'
 
-RSpec.feature'Tasks', type: :feature, js: true do
+RSpec.feature 'Tasks', type: :feature, js: true do
   let!(:user) { create(:user, accountid: 'IamTest', password: 'testPassword') }
   context 'ログインしている場合' do
     before do

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -4,44 +4,39 @@ require 'rails_helper'
 
 RSpec.feature'Tasks', type: :feature, js: true do
   let(:task) { create(:task) }
-  describe 'タスクの一覧表示' do
+  let!(:user) { create(:user, accountid: 'IamTest', password: 'testPassword') }
+  context 'ログインしている場合' do
     before do
-      create(:task, title: 'Test2', importance: 2, status: 0, dead_line_on: '2020-07-24', created_at: '2020/07/24 16:00::55')
-      create(:task, title: 'Test1', importance: 1, status: 1, dead_line_on: '2020-08-09', created_at: '2020/08/09 09:00:00')
-      visit tasks_path
+      visit login_path
+      fill_in 'accountid', with: 'IamTest'
+      fill_in 'password', with: 'testPassword'
+      click_button 'ログイン'
+      sleep 1
     end
-
-    describe '最初の並び順' do
-      it 'indexページに投稿されたタスクの一覧が表示される' do
-        within all('tr.tasks')[0] do
-          expect(find('th.title')).to have_content 'Test1'
-          expect(find('th.importance')).to have_content '中'
-          expect(find('th.status')).to have_content '着手'
-          expect(find('th.dead_line_on')).to have_content '2020-08-09'
-          expect(find('th.created_day')).to have_content '2020/08/09'
-        end
-        within all('tr.tasks')[1] do
-          expect(find('th.title')).to have_content 'Test2'
-          expect(find('th.importance')).to have_content '高'
-          expect(find('th.status')).to have_content '未着手'
-          expect(find('th.dead_line_on')).to have_content '2020-07-24'
-          expect(find('th.created_day')).to have_content '2020/07/24'
-        end
+    describe 'タスクの一覧表示' do
+      before do
+        create(:task, title: 'Test2', user: user, importance: 2, status: 0, dead_line_on: '2020-07-24', created_at: '2020/07/24 16:00::55')
+        create(:task, title: 'Test1', user: user, importance: 1, status: 1, dead_line_on: '2020-08-09', created_at: '2020/08/09 09:00:00')
+        visit tasks_path
       end
-      it 'ページ遷移後、投稿日が新しい順に並んでいる' do
-        within all('tr.tasks')[0] do
-          expect(find('th.created_day')).to have_content '2020/08/09'
+      describe '最初の並び順' do
+        it 'indexページに投稿されたタスクの一覧が表示される' do
+          within all('tr.tasks')[0] do
+            expect(find('th.title')).to have_content 'Test1'
+            expect(find('th.importance')).to have_content '中'
+            expect(find('th.status')).to have_content '着手'
+            expect(find('th.dead_line_on')).to have_content '2020-08-09'
+            expect(find('th.created_day')).to have_content '2020/08/09'
+          end
+          within all('tr.tasks')[1] do
+            expect(find('th.title')).to have_content 'Test2'
+            expect(find('th.importance')).to have_content '高'
+            expect(find('th.status')).to have_content '未着手'
+            expect(find('th.dead_line_on')).to have_content '2020-07-24'
+            expect(find('th.created_day')).to have_content '2020/07/24'
+          end
         end
-        within all('tr.tasks')[1] do
-          expect(find('th.created_day')).to have_content '2020/07/24'
-        end
-      end
-    end
-
-    describe '並び替え' do
-      context '投稿日が新しい順' do
-        before { click_button '投稿日順' }
-        it '投稿日が新しい順に並び替える' do
+        it 'ページ遷移後、投稿日が新しい順に並んでいる' do
           within all('tr.tasks')[0] do
             expect(find('th.created_day')).to have_content '2020/08/09'
           end
@@ -51,235 +46,247 @@ RSpec.feature'Tasks', type: :feature, js: true do
         end
       end
 
-      context '投稿日が古い順' do
-        before do
-          click_button '投稿日順'
-          click_button '投稿日順'
+      describe '並び替え' do
+        context '投稿日が新しい順' do
+          before { click_button '投稿日順' }
+          it '投稿日が新しい順に並び替える' do
+            within all('tr.tasks')[0] do
+              expect(find('th.created_day')).to have_content '2020/08/09'
+            end
+            within all('tr.tasks')[1] do
+              expect(find('th.created_day')).to have_content '2020/07/24'
+            end
+          end
         end
-        it '投稿日が古い順に並び替える' do
+
+        context '投稿日が古い順' do
+          before do
+            click_button '投稿日順'
+            click_button '投稿日順'
+          end
+          it '投稿日が古い順に並び替える' do
+            within all('tr.tasks')[0] do
+              expect(find('th.created_day')).to have_content '2020/07/24'
+            end
+            within all('tr.tasks')[1] do
+              expect(find('th.created_day')).to have_content  '2020/08/09'
+            end
+          end
+        end
+
+        context '期限日が近い順' do
+          before { click_button '期限日順' }
+          it '期限が近い順に並び替える' do
+            within all('tr.tasks')[0] do
+              expect(find('th.dead_line_on')).to have_content '2020-07-24'
+            end
+            within all('tr.tasks')[1] do
+              expect(find('th.dead_line_on')).to have_content '2020-08-09'
+            end
+          end
+        end
+        context '期限日が遠いの順' do
+          before do
+            click_button '期限日順'
+            click_button '期限日順'
+          end
+          it '期限が遠い順に並び替える' do
+            within all('tr.tasks')[0] do
+              expect(find('th.dead_line_on')).to have_content '2020-08-09'
+            end
+            within all('tr.tasks')[1] do
+              expect(find('th.dead_line_on')).to have_content '2020-07-24'
+            end
+          end
+        end
+
+        context '優先度が高い順' do
+          before { click_button '優先順位順' }
+          it '優先度が高い順に並び替える' do
+            within all('tr.tasks')[0] do
+              expect(find('th.importance')).to have_content '高'
+            end
+            within all('tr.tasks')[1] do
+              expect(find('th.importance')).to have_content '中'
+            end
+          end
+        end
+
+        context '優先度が低い順' do
+          before do
+            click_button '優先順位順'
+            click_button '優先順位順'
+          end
+          it '優先度が低い順に並び替える' do
+            within all('tr.tasks')[0] do
+              expect(find('th.importance')).to have_content '中'
+            end
+            within all('tr.tasks')[1] do
+              expect(find('th.importance')).to have_content '高'
+            end
+          end
+        end
+      end
+
+      describe '絞り込み検索' do
+        before { click_button '検索条件をリセット' }
+        it 'フォーム検索' do
+          fill_in 'query', with: 'Test2'
+          click_button '検索'
+          expect(page).to have_selector 'tr.tasks', count: 1
           within all('tr.tasks')[0] do
-            expect(find('th.created_day')).to have_content '2020/07/24'
-          end
-          within all('tr.tasks')[1] do
-            expect(find('th.created_day')).to have_content  '2020/08/09'
+            expect(find('th.title')).to have_content 'Test2'
           end
         end
-      end
-
-      context '期限日が近い順' do
-        before { click_button '期限日順' }
-        it '期限が近い順に並び替える' do
+        it 'ステータス検索' do
+          select '着手', from: 'status'
+          click_button '検索'
+          expect(page).to have_selector 'tr.tasks', count: 1
           within all('tr.tasks')[0] do
-            expect(find('th.dead_line_on')).to have_content '2020-07-24'
-          end
-          within all('tr.tasks')[1] do
-            expect(find('th.dead_line_on')).to have_content '2020-08-09'
+            expect(find('th.status')).to have_content '着手'
           end
         end
-      end
-      context '期限日が遠いの順' do
-        before do
-          click_button '期限日順'
-          click_button '期限日順'
-        end
-        it '期限が遠い順に並び替える' do
+        it 'フォームとステータスで検索' do
+          fill_in 'query', with: 'Test1'
+          select '着手', from: 'status'
+          click_button '検索'
+          expect(page).to have_selector 'tr.tasks', count: 1
           within all('tr.tasks')[0] do
-            expect(find('th.dead_line_on')).to have_content '2020-08-09'
-          end
-          within all('tr.tasks')[1] do
-            expect(find('th.dead_line_on')).to have_content '2020-07-24'
-          end
-        end
-      end
-
-      context '優先度が高い順' do
-        before { click_button '優先順位順' }
-        it '優先度が高い順に並び替える' do
-          within all('tr.tasks')[0] do
-            expect(find('th.importance')).to have_content '高'
-          end
-          within all('tr.tasks')[1] do
-            expect(find('th.importance')).to have_content '中'
-          end
-        end
-      end
-
-      context '優先度が低い順' do
-        before do
-          click_button '優先順位順'
-          click_button '優先順位順'
-        end
-        it '優先度が低い順に並び替える' do
-          within all('tr.tasks')[0] do
-            expect(find('th.importance')).to have_content '中'
-          end
-          within all('tr.tasks')[1] do
-            expect(find('th.importance')).to have_content '高'
+            expect(find('th.title')).to have_content 'Test1'
+            expect(find('th.status')).to have_content '着手'
           end
         end
       end
     end
 
-    describe '絞り込み検索' do
-      before { click_button '検索条件をリセット' }
-      it 'フォーム検索' do
-        fill_in 'query', with: 'Test2'
-        click_button '検索'
-        expect(page).to have_selector 'tr.tasks', count: 1
-        within all('tr.tasks')[0] do
-          expect(find('th.title')).to have_content 'Test2'
-        end
-      end
-      it 'ステータス検索' do
-        select '着手', from: 'status'
-        click_button '検索'
-        expect(page).to have_selector 'tr.tasks', count: 1
-        within all('tr.tasks')[0] do
-          expect(find('th.status')).to have_content '着手'
-        end
-      end
-      it 'フォームとステータスで検索' do
-        fill_in 'query', with: 'Test1'
-        select '着手', from: 'status'
-        click_button '検索'
-        expect(page).to have_selector 'tr.tasks', count: 1
-        within all('tr.tasks')[0] do
-          expect(find('th.title')).to have_content 'Test1'
-          expect(find('th.status')).to have_content '着手'
-        end
-      end
-    end
-  end
-
-  describe 'タスクの投稿' do
-    let!(:user) { create(:user) }
-    before { visit tasks_path }
-    context '必要な値を入力している場合' do
-      before do
-        click_link 'タスクの投稿'
-        fill_in 'task_title', with: 'feature_test'
-        select '高', from: 'task_importance'
-        select '2020', from: 'task_dead_line_on_1i'
-        select '7', from: 'task_dead_line_on_2i'
-        select '24', from: 'task_dead_line_on_3i'
-        select '着手', from: 'task_status'
-        fill_in 'task_detail', with: '東京オリンピック開会日'
-        click_button '登録する'
-      end
-      it '投稿に成功する' do
-        expect(page).to have_content '新しいタスクが作成されました'
-      end
-    end
-    context 'task_titleが空の場合' do
-      before do
-        click_link 'タスクの投稿'
-        fill_in 'task_title', with: nil
-        select '高', from: 'task_importance'
-        select '2020', from: 'task_dead_line_on_1i'
-        select '7', from: 'task_dead_line_on_2i'
-        select '24', from: 'task_dead_line_on_3i'
-        select '着手', from: 'task_status'
-        fill_in 'task_detail', with: '東京オリンピック開会日'
-        click_button '登録する'
-      end
-      it '投稿に失敗する' do
-        expect(page).to have_content 'タスクの作成に失敗しました'
-        expect(page).to have_content 'タイトルを入力してください'
-      end
-    end
-    context 'task_titleが30文字以上の場合' do
-      before do
-        click_link 'タスクの投稿'
-        fill_in 'task_title', with: '12345678910/12345678910/12345678910'
-        select '高', from: 'task_importance'
-        select '2020', from: 'task_dead_line_on_1i'
-        select '7', from: 'task_dead_line_on_2i'
-        select '24', from: 'task_dead_line_on_3i'
-        select '着手', from: 'task_status'
-        fill_in 'task_detail', with: '東京オリンピック開会日'
-        click_button '登録する'
-      end
-      it '投稿に失敗する' do
-        expect(page).to have_content 'タスクの作成に失敗しました'
-        expect(page).to have_content 'タイトルは30文字以内で入力してください'
-      end
-    end
-    context 'dead_line_onの日付が過去の日付の場合' do
-      before do
-        click_link 'タスクの投稿'
-        fill_in 'task_title', with: 'feature_test'
-        select '高', from: 'task_importance'
-        select '2016', from: 'task_dead_line_on_1i'
-        select '8', from: 'task_dead_line_on_2i'
-        select '5', from: 'task_dead_line_on_3i'
-        select '着手', from: 'task_status'
-        fill_in 'task_detail', with: 'リオデジャネイロオリンピック開会日'
-        click_button '登録する'
-      end
-      it '投稿に失敗する' do
-        expect(page).to have_content 'タスクの作成に失敗しました'
-        expect(page).to have_content '期限に過去の日付は使用できません'
-      end
-    end
-  end
-
-  describe 'タスクを表示しているページの切り替え' do
-    context '10個以下の場合' do
-      before do
-        10.times { create(:task) }
-        visit current_path
-      end
-      it '10個まで表示される' do
-        expect(all('tr.tasks').size).to eq 10
-      end
-      it 'ページネーションできない' do
-        expect(page).to have_button 'Go Next', disabled: true
-        expect(page).to have_button 'Go Back', disabled: true
-      end
-    end
-    context 'タスクが11個以上から20個の場合' do
-      before do
-        20.times { create(:task) }
-        visit current_path
-      end
-      it '2ページ目に11個目から20個目までが表示される' do
-        click_button 'Go Next'
-        expect(all('tr.tasks').size).to eq 10
-      end
-    end
-  end
-
-  describe 'タスクの編集、更新、削除' do
-    before do
-      visit tasks_path
-      visit task_path(task.id)
-    end
-
-    describe '編集と更新' do
+    describe 'タスクの投稿' do
       context '必要な値を入力している場合' do
         before do
-          click_link '編集'
-          fill_in 'task_title', with: 'タスクの更新'
-          click_button '更新する'
+          click_link 'タスクの投稿'
+          fill_in 'task_title', with: 'feature_test'
+          select '高', from: 'task_importance'
+          select '2020', from: 'task_dead_line_on_1i'
+          select '7', from: 'task_dead_line_on_2i'
+          select '24', from: 'task_dead_line_on_3i'
+          select '着手', from: 'task_status'
+          fill_in 'task_detail', with: '東京オリンピック開会日'
+          click_button '登録する'
         end
-        it '作成したタスクの更新する' do
-          expect(page).to have_content 'タスクの内容が更新されました'
+        it '投稿に成功する' do
+          expect(page).to have_content '新しいタスクが作成されました'
+        end
+      end
+      context 'task_titleが空の場合' do
+        before do
+          click_link 'タスクの投稿'
+          fill_in 'task_title', with: nil
+          select '高', from: 'task_importance'
+          select '2020', from: 'task_dead_line_on_1i'
+          select '7', from: 'task_dead_line_on_2i'
+          select '24', from: 'task_dead_line_on_3i'
+          select '着手', from: 'task_status'
+          fill_in 'task_detail', with: '東京オリンピック開会日'
+          click_button '登録する'
+        end
+        it '投稿に失敗する' do
+          expect(page).to have_content 'タスクの作成に失敗しました'
+          expect(page).to have_content 'タイトルを入力してください'
+        end
+      end
+      context 'task_titleが30文字以上の場合' do
+        before do
+          click_link 'タスクの投稿'
+          fill_in 'task_title', with: '12345678910/12345678910/12345678910'
+          select '高', from: 'task_importance'
+          select '2020', from: 'task_dead_line_on_1i'
+          select '7', from: 'task_dead_line_on_2i'
+          select '24', from: 'task_dead_line_on_3i'
+          select '着手', from: 'task_status'
+          fill_in 'task_detail', with: '東京オリンピック開会日'
+          click_button '登録する'
+        end
+        it '投稿に失敗する' do
+          expect(page).to have_content 'タスクの作成に失敗しました'
+          expect(page).to have_content 'タイトルは30文字以内で入力してください'
+        end
+      end
+      context 'dead_line_onの日付が過去の日付の場合' do
+        before do
+          click_link 'タスクの投稿'
+          fill_in 'task_title', with: 'feature_test'
+          select '高', from: 'task_importance'
+          select '2016', from: 'task_dead_line_on_1i'
+          select '8', from: 'task_dead_line_on_2i'
+          select '5', from: 'task_dead_line_on_3i'
+          select '着手', from: 'task_status'
+          fill_in 'task_detail', with: 'リオデジャネイロオリンピック開会日'
+          click_button '登録する'
+        end
+        it '投稿に失敗する' do
+          expect(page).to have_content 'タスクの作成に失敗しました'
+          expect(page).to have_content '期限に過去の日付は使用できません'
         end
       end
     end
 
-    describe '削除' do
-      before { click_link '削除' }
-      context '確認時、Yesを選んだ場合' do
-        it '削除される' do
-          page.driver.browser.switch_to.alert.accept
-          expect(page).to have_content 'タスクを削除しました'
+    describe 'タスクを表示しているページの切り替え' do
+      context '10個以下の場合' do
+        before do
+          10.times { create(:task, user: user) }
+          visit tasks_path
+        end
+        it '10個まで表示される' do
+          expect(all('tr.tasks').size).to eq 10
+        end
+        it 'ページネーションできない' do
+          expect(page).to have_button 'Go Next', disabled: true
+          expect(page).to have_button 'Go Back', disabled: true
         end
       end
-      context '確認時、Noを選んだ場合' do
-        it '削除されない' do
-          page.driver.browser.switch_to.alert.dismiss
-          expect(page).to have_content 'タスクの詳細'
+      context 'タスクが11個以上から20個の場合' do
+        before do
+          20.times { create(:task, user: user) }
+          visit tasks_path
+        end
+        it '2ページ目に11個目から20個目までが表示される' do
+          click_button 'Go Next'
+          expect(all('tr.tasks').size).to eq 10
+        end
+      end
+    end
+
+    describe 'タスクの編集、更新、削除' do
+      before do
+        visit tasks_path
+        visit task_path(task.id)
+      end
+
+      describe '編集と更新' do
+        context '必要な値を入力している場合' do
+          before do
+            click_link '編集'
+            fill_in 'task_title', with: 'タスクの更新'
+            click_button '更新する'
+          end
+          it '作成したタスクの更新する' do
+            expect(page).to have_content 'タスクの内容が更新されました'
+          end
+        end
+      end
+
+      describe '削除' do
+        before { click_link '削除' }
+        context '確認時、Yesを選んだ場合' do
+          it '削除される' do
+            page.driver.browser.switch_to.alert.accept
+            expect(page).to have_content 'タスクを削除しました'
+          end
+        end
+        context '確認時、Noを選んだ場合' do
+          it '削除されない' do
+            page.driver.browser.switch_to.alert.dismiss
+            expect(page).to have_content 'タスクの詳細'
+          end
         end
       end
     end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -3,7 +3,6 @@
 require 'rails_helper'
 
 RSpec.feature'Tasks', type: :feature, js: true do
-  let(:task) { create(:task) }
   let!(:user) { create(:user, accountid: 'IamTest', password: 'testPassword') }
   context 'ログインしている場合' do
     before do
@@ -268,6 +267,7 @@ RSpec.feature'Tasks', type: :feature, js: true do
     end
 
     describe 'タスクの編集、更新、削除' do
+      let(:task) { create(:task, user: user) }
       before do
         visit tasks_path
         visit task_path(task.id)

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -14,11 +14,11 @@ RSpec.feature'Tasks', type: :feature, js: true do
       sleep 1
     end
     describe 'タスクの一覧表示' do
-      before do
+      let!(:tasks_for_listing_test) do
         create(:task, title: 'Test2', user: user, importance: 2, status: 0, dead_line_on: '2020-07-24', created_at: '2020/07/24 16:00::55')
         create(:task, title: 'Test1', user: user, importance: 1, status: 1, dead_line_on: '2020-08-09', created_at: '2020/08/09 09:00:00')
-        visit tasks_path
       end
+      before { visit tasks_path }
       describe '最初の並び順' do
         it 'indexページに投稿されたタスクの一覧が表示される' do
           within all('tr.tasks')[0] do
@@ -243,8 +243,8 @@ RSpec.feature'Tasks', type: :feature, js: true do
 
     describe 'タスクを表示しているページの切り替え' do
       context '10個以下の場合' do
+        let!(:tasks_for_pagination_test) { 10.times { create(:task, user: user) } }
         before do
-          10.times { create(:task, user: user) }
           visit tasks_path
         end
         it '10個まで表示される' do
@@ -256,8 +256,8 @@ RSpec.feature'Tasks', type: :feature, js: true do
         end
       end
       context 'タスクが11個以上から20個の場合' do
+        let!(:tasks_for_pagination_test) { 20.times { create(:task, user: user) } }
         before do
-          20.times { create(:task, user: user) }
           visit tasks_path
           click_button 'Go Next'
         end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -291,4 +291,26 @@ RSpec.feature'Tasks', type: :feature, js: true do
       end
     end
   end
+  context 'ログインしていない場合' do
+    context 'ログインせず、別の画面に遷移しようとした場合' do
+      it 'ログイン画面に遷移する' do
+        visit tasks_path
+        expect(current_path).to eq login_path
+        expect(page).to have_content 'ログインを行なってください'
+      end
+    end
+    context 'ログイン画面から別の画面に遷移しようとした場合' do
+      before { visit login_path }
+      it 'タスク一覧画面に遷移しようとしても、ログイン画面に遷移する' do
+        click_link 'タスク一覧'
+        expect(current_path).to eq login_path
+        expect(page).to have_content 'ログインを行なってください'
+      end
+      it 'タスク投稿画面に遷移しようとしても、ログイン画面に遷移する' do
+        click_link 'タスクの投稿'
+        expect(current_path).to eq login_path
+        expect(page).to have_content 'ログインを行なってください'
+      end
+    end
+  end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -10,7 +10,7 @@ RSpec.feature'Tasks', type: :feature, js: true do
       fill_in 'accountid', with: 'IamTest'
       fill_in 'password', with: 'testPassword'
       click_button 'ログイン'
-      sleep 1
+      expect(page).to have_content 'タスク一覧'
     end
     describe 'タスクの一覧表示' do
       let!(:tasks_for_listing_test) do

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -9,15 +9,17 @@ RSpec.describe 'Api::Tasks', type: :request do
       accountid: 'tester',
       password: 'IamTestMan'
     }
-    2.times { create(:task, user: user) }
-    2.times { create(:task) }
+    2.times { create(:task, title: 'login_userd_task', user: user) }
+    3.times { create(:task) }
   end
   describe 'GET#index' do
     context 'ログインを行なっている場合' do
       it '自分が投稿したタスクのみが表示される' do
         get api_tasks_path
-        tasks = JSON.parse(response.body)['nested']['data']
-        expect(tasks.length).to eq 2
+        login_user_tasks = JSON.parse(response.body)['nested']['data']
+        expect(login_user_tasks.length).to eq 2
+        expect(login_user_tasks[0]['title']).to eq 'login_userd_task'
+        expect(login_user_tasks[1]['title']).to eq 'login_userd_task'
       end
     end
   end

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -1,0 +1,24 @@
+# frozen_string_literal: true
+
+require 'rails_helper'
+
+RSpec.describe 'Api::Tasks', type: :request do
+  let!(:user) { create(:user, accountid: 'tester', password: 'IamTestMan') }
+  before do
+    post login_path, params: {
+      accountid: 'tester',
+      password: 'IamTestMan'
+    }
+    2.times { create(:task, user: user) }
+    2.times { create(:task) }
+  end
+  describe 'GET#index' do
+    context 'ログインを行なっている場合' do
+      it '自分が投稿したタスクのみが表示される' do
+        get api_tasks_path
+        tasks = JSON.parse(response.body)['nested']['data']
+        expect(tasks.length).to eq 2
+      end
+    end
+  end
+end


### PR DESCRIPTION
## やったこと
- ログインしているユーザーのタスクのみが表示される様にする
- ログインせず、タスクの一覧表示画面や投稿画面に遷移しようとした場合、強制的にログイン画面に遷移される様にする

## 関連するissue
#38 