### PR TITLE
ログアウト機能（サーバーサイド側）の実装

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -18,5 +18,7 @@ class SessionsController < ApplicationController
 
   def destroy
     log_out
+    delete_long_duration_cookie_for current_user
+    render json: 'ログアウトに成功しました', status: 200
   end
 end

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -15,4 +15,8 @@ class SessionsController < ApplicationController
       render json: 'ログインに失敗しました。IDとパスワードを確認してください。', status: 401
     end
   end
+
+  def destroy
+    log_out
+  end
 end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -15,6 +15,12 @@ module SessionsHelper
     cookies.signed[:user_id] = { value: user.id, expires: 1.weeks.from_now }
   end
 
+  def delete_long_duration_cookie_for(user)
+    user.delete_cookie_token!
+    cookies.delete(:user_token)
+    cookies.delete(:user_id)
+  end
+
   def current_user
     User.find(cookies.signed[:user_id]) if cookies[:user_id].present?
   end

--- a/app/helpers/sessions_helper.rb
+++ b/app/helpers/sessions_helper.rb
@@ -5,6 +5,10 @@ module SessionsHelper
     session[:user_id] = user.id
   end
 
+  def log_out
+    session.delete(:user_id)
+  end
+
   def make_long_duration_cookie_for(user)
     user.make_cookie_token!
     cookies[:user_token] = { value: user.cookie_token, expires: 1.weeks.from_now }

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -39,6 +39,7 @@ class User < ApplicationRecord
     self.cookie_token = nil
     update_attributes(hashed_cookie_token: nil)
   end
+
   private
 
   def hashing_with_salt(salt, plain_text)

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -35,6 +35,10 @@ class User < ApplicationRecord
     update_attributes(hashed_cookie_token: hashing_with_salt(salt, cookie_token))
   end
 
+  def delete_cookie_token!
+    self.cookie_token = nil
+    update_attributes(hashed_cookie_token: nil)
+  end
   private
 
   def hashing_with_salt(salt, plain_text)

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -119,5 +119,17 @@ RSpec.describe User, type: :model do
         it { is_expected.not_to include user.cookie_token }
       end
     end
+    describe '#delete_cookie_token!' do
+      before do
+        user.make_cookie_token!
+        user.delete_cookie_token!
+      end
+      it '紐づけられていたcookie_tokenがなくなる' do
+        expect(user.cookie_token).to eq nil
+      end
+      it 'データベースに保村されていたcookie_tokenがなくなる' do
+        expect(user.hashed_cookie_token).to eq nil
+      end
+    end
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -89,6 +89,9 @@ RSpec.describe 'Session', type: :request do
       it 'レスポンスからユーザーの記憶トークンが取り除かれる' do
         expect(response.cookies['user_token']).to eq nil
       end
+      it 'レスポンスでログアウト成功を伝えるメッセージが返る' do
+        expect(response.body).to eq 'ログアウトに成功しました'
+      end
     end
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -69,8 +69,8 @@ RSpec.describe 'Session', type: :request do
     let!(:user) { create(:user, name: 'Json', accountid: 'Iamtest', password: 'thisisTest') }
     let!(:log_in) do
       post login_path, params: {
-          accountid: 'Iamtest',
-          password: 'thisisTest'
+        accountid: 'Iamtest',
+        password: 'thisisTest'
       }
     end
     before do

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -80,6 +80,15 @@ RSpec.describe 'Session', type: :request do
       it 'sessionからユーザーIDの値が削除される' do
         expect(session[:user_id]).to eq nil
       end
+      it 'レスポンスのステータスが200' do
+        expect(response.status).to eq 200
+      end
+      it 'レスポンスから暗号化されたユーザーIDの情報が取り除かれる' do
+        expect(response.cookies['user_id']).to eq nil
+      end
+      it 'レスポンスからユーザーの記憶トークンが取り除かれる' do
+        expect(response.cookies['user_token']).to eq nil
+      end
     end
   end
 end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -65,4 +65,21 @@ RSpec.describe 'Session', type: :request do
       end
     end
   end
+  describe 'DELETE#destroy' do
+    let!(:user) { create(:user, name: 'Json', accountid: 'Iamtest', password: 'thisisTest') }
+    let!(:log_in) do
+      post login_path, params: {
+          accountid: 'Iamtest',
+          password: 'thisisTest'
+      }
+    end
+    before do
+      delete logout_path
+    end
+    context 'ログイン済みのユーザーの場合' do
+      it 'sessionからユーザーIDの値が削除される' do
+        expect(session[:user_id]).to eq nil
+      end
+    end
+  end
 end


### PR DESCRIPTION
## やったこと
- sessions#destroy でユーザーのセッションを切り、ログインしていたユーザーのcookie情報を削除できる様にする
  - データベースに保存されている `hashed_cookie_token`も削除される

## merge先が fillter_tasks_posted_by_current_userな理由
- fillter_tasks_posted_by_current_userから作業ブランチを切ったので、そちらがmasterにマージされてからmerge先をmasterに向ける様にする