### PR TITLE
toastrで表示するメッセージの修正

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -12,7 +12,7 @@ class SessionsController < ApplicationController
       make_long_duration_cookie_for @user
       render json: { user: @user, redirect_url: LOGIN_SUCCESS_URL }, status: 200
     else
-      render json: 'ログインに失敗しました', status: 401
+      render json: 'ログインに失敗しました。IDとパスワードを確認してください。', status: 401
     end
   end
 end

--- a/app/javascript/packs/sessions/sessions_vue.js
+++ b/app/javascript/packs/sessions/sessions_vue.js
@@ -16,9 +16,8 @@ window.loginForm = new Vue({
                           new URLSearchParams({'accountid': this.accountid, 'password': this.password})
       ).then(function(response) {
         window.location.href = response.data.redirect_url;
-        toastr.success('ログインに成功しました。');
-      }).catch(function() {
-        toastr.error('ログインに失敗しました。IDとパスワードを確認してください。');
+      }).catch(function(error) {
+        toastr.error(error.response.data);
       }).finally(function() {
         this.reloadForm(1000);
       }.bind(this));

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -58,7 +58,7 @@ RSpec.describe 'Session', type: :request do
         expect(response.header['Set-Cookie']).to be_nil
       end
       it 'レスポンスでアラートメッセージが返ってくる' do
-        expect(response.body).to eq 'ログインに失敗しました'
+        expect(response.body).to eq 'ログインに失敗しました。IDとパスワードを確認してください。'
       end
       it 'レスポンスのステータスが401' do
         expect(response.status).to eq 401


### PR DESCRIPTION
## やったこと
- 成功時、tostrメッセージが遷移後の画面に表示されなかったので、そもそも表示しないように修正
- 失敗時に表示するエラーメッセージをサーバーサイドから返されたものを使用するように変更