### PR TITLE
ログアウト機能（フロント側）の実装

### DIFF
--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -3,6 +3,8 @@
 class SessionsController < ApplicationController
   include SessionsHelper
   LOGIN_SUCCESS_URL = '/tasks'
+  LOGOUT_SUCCESS_URL = '/login'
+
   def new; end
 
   def create
@@ -19,6 +21,6 @@ class SessionsController < ApplicationController
   def destroy
     log_out
     delete_long_duration_cookie_for current_user
-    render json: 'ログアウトに成功しました', status: 200
+    render json: LOGOUT_SUCCESS_URL, status: 200
   end
 end

--- a/app/javascript/packs/sessions/logout_vue.js
+++ b/app/javascript/packs/sessions/logout_vue.js
@@ -1,18 +1,17 @@
 import Vue from 'vue';
 import prepareAxios from '../modules/axios';
-import toastr from 'toastr';
 
-window.logoutLink = new Vue ({
+window.logoutLink = new Vue({
   el: '#logout_link',
   data: {
-    logout_url: '/logout'
+    logout_url: '/logout',
   },
   methods: {
     requestLogout: function() {
       prepareAxios({withCsrf: true, withCookie: true}).delete(this.logout_url)
-      .then(function(response) {
-        window.location.href = response.data;
-      });
+        .then(function(response) {
+          window.location.href = response.data;
+        });
     },
-  }
+  },
 });

--- a/app/javascript/packs/sessions/logout_vue.js
+++ b/app/javascript/packs/sessions/logout_vue.js
@@ -1,0 +1,18 @@
+import Vue from 'vue';
+import prepareAxios from '../modules/axios';
+import toastr from 'toastr';
+
+window.logoutLink = new Vue ({
+  el: '#logout_link',
+  data: {
+    logout_url: '/logout'
+  },
+  methods: {
+    requestLogout: function() {
+      prepareAxios({withCsrf: true, withCookie: true}).delete(this.logout_url)
+      .then(function(response) {
+        window.location.href = response.data;
+      });
+    },
+  }
+});

--- a/app/views/layouts/_header.slim
+++ b/app/views/layouts/_header.slim
@@ -1,0 +1,13 @@
+nav.navbar.navbar-expand-lg.application_header
+  .navbar-header
+    = link_to "TaskApp", tasks_path, class: "navbar-brand logo"
+  ul.nav.navbar-nav.navbar-nav_extend
+    li.nav-item
+      = link_to "タスク一覧", tasks_path, class: "nav-link"
+    li.nav-item
+      = link_to "タスクの投稿", new_task_path, class: "nav-link"
+    li.nav-item
+      = link_to "ログアウト", logout_path, method: :delete, 'v-on:click.prevent': 'requestLogout', class: "nav-link", id: "logout_link", data: { confirm: 'ログアウトしますか？' } if logged_in?
+      = link_to "ログイン", login_path, class: "nav-link", id: 'login_link' unless logged_in?
+
+= javascript_pack_tag 'sessions/logout_vue'

--- a/app/views/layouts/application.html.slim
+++ b/app/views/layouts/application.html.slim
@@ -8,14 +8,7 @@ html
     = stylesheet_link_tag    'application', media: 'all', 'data-turbolinks-track': 'reload'
     = javascript_include_tag 'application'
   body
-    nav.navbar.navbar-expand-lg.application_header
-      .navbar-header
-        = link_to "TaskApp", tasks_path, class: "navbar-brand logo"
-      ul.nav.navbar-nav.navbar-nav_extend
-        li.nav-item
-          = link_to "タスク一覧", tasks_path, class: "nav-link"
-        li.nav-item
-          = link_to "タスクの投稿", new_task_path, class: "nav-link"
+    = render partial: "layouts/header"
     .spring
       = render partial: "layouts/flash", locals: { flash: flash } if flash.present?
       = yield

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -55,4 +55,37 @@ RSpec.feature 'Sessions', type: :feature, js: true do
       end
     end
   end
+  describe 'ログアウト' do
+    let!(:user) { create(:user, accountid: 'Iamtest', password: 'testPassword') }
+    before  do
+      visit login_path
+      fill_in 'accountid', with: 'Iamtest'
+      fill_in 'password', with: 'testPassword'
+      click_button 'ログイン'
+      expect(page).to have_content 'タスク一覧'
+      visit tasks_path
+      click_link 'ログアウト'
+    end
+    context '確認ダイアログでYesを押した場合' do
+      before { page.driver.browser.switch_to.alert.accept }
+      it 'ログイン画面に遷移する'
+      # expect(page).to have_content 'ログイン'
+      context 'ログアウトした後'do
+        before { visit tasks_path }
+        it 'ログアウトのリンクが表示されなくなり、ログインのリンクが表示される' do
+          expect(page).not_to have_selector 'a#logout_link', text: 'ログアウト'
+          expect(page).to have_selector 'a#login_link', text: 'ログイン'
+        end
+      end
+    end
+    context '確認ダイアログでNoを押した場合' do
+      before { page.driver.browser.switch_to.alert.dismiss }
+      # it '画面は変わらない'
+      #   expect(current_path).to eq tasks_path
+      it 'ログアウトのリンクが表示され、ログインのリンクは表示されない' do
+        expect(page).not_to have_selector 'a#login_link', text: 'ログイン'
+        expect(page).to have_selector 'a#logout_link', text: 'ログアウト'
+      end
+    end
+  end
 end

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -15,10 +15,10 @@ RSpec.feature 'Sessions', type: :feature, js: true do
         fill_in 'accountid', with: accountid
         fill_in 'password', with: password
         click_button 'ログイン'
-      end
-      it 'タスク一覧画面に遷移する' do
         expect(page).to have_content 'タスク一覧'
       end
+      it 'タスク一覧画面に遷移する'
+        # expect(page).to have_selector '#title_log'
     end
     context '登録されているユーザーとアカウントIDとパスワードが異なる場合' do
       before do
@@ -31,14 +31,13 @@ RSpec.feature 'Sessions', type: :feature, js: true do
       end
       context '入力を間違えた後、登録されているユーザーのアカウントIDとパスワードを入力した場合' do
         before do
-          sleep 2
           fill_in 'accountid', with: accountid
           fill_in 'password', with: password
           click_button 'ログイン'
-        end
-        it 'タスク一覧画面に遷移する' do
           expect(page).to have_content 'タスク一覧'
         end
+        it 'タスク一覧画面に遷移する'
+          # expect(page).to have_content 'タスク一覧'
       end
     end
   end

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -18,7 +18,6 @@ RSpec.feature 'Sessions', type: :feature, js: true do
         expect(page).to have_content 'タスク一覧'
       end
       it 'タスク一覧画面に遷移する'
-      # expect(page).to have_selector '#title_log'
       context 'ログインした後' do
         before { visit tasks_path }
         it 'ログインのリンクが表示されなくなり、ログアウトのリンクが表示される' do
@@ -44,7 +43,6 @@ RSpec.feature 'Sessions', type: :feature, js: true do
           expect(page).to have_content 'タスク一覧'
         end
         it 'タスク一覧画面に遷移する'
-        # expect(page).to have_content 'タスク一覧'
         context 'ログインした後' do
           before { visit tasks_path }
           it 'ログインのリンクが表示されなくなり、ログアウトのリンクが表示される' do
@@ -69,7 +67,6 @@ RSpec.feature 'Sessions', type: :feature, js: true do
     context '確認ダイアログでYesを押した場合' do
       before { page.driver.browser.switch_to.alert.accept }
       it 'ログイン画面に遷移する'
-      # expect(page).to have_content 'ログイン'
       context 'ログアウトした後' do
         before { visit tasks_path }
         it 'ログアウトのリンクが表示されなくなり、ログインのリンクが表示される' do
@@ -81,7 +78,6 @@ RSpec.feature 'Sessions', type: :feature, js: true do
     context '確認ダイアログでNoを押した場合' do
       before { page.driver.browser.switch_to.alert.dismiss }
       it '画面は変わらない'
-      #   expect(current_path).to eq tasks_path
       it 'ログアウトのリンクが表示され、ログインのリンクは表示されない' do
         expect(page).not_to have_selector 'a#login_link', text: 'ログイン'
         expect(page).to have_selector 'a#logout_link', text: 'ログアウト'

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -18,7 +18,7 @@ RSpec.feature 'Sessions', type: :feature, js: true do
         expect(page).to have_content 'タスク一覧'
       end
       it 'タスク一覧画面に遷移する'
-        # expect(page).to have_selector '#title_log'
+      # expect(page).to have_selector '#title_log'
       context 'ログインした後' do
         before { visit tasks_path }
         it 'ログインのリンクが表示されなくなり、ログアウトのリンクが表示される' do
@@ -44,7 +44,7 @@ RSpec.feature 'Sessions', type: :feature, js: true do
           expect(page).to have_content 'タスク一覧'
         end
         it 'タスク一覧画面に遷移する'
-          # expect(page).to have_content 'タスク一覧'
+        # expect(page).to have_content 'タスク一覧'
         context 'ログインした後' do
           before { visit tasks_path }
           it 'ログインのリンクが表示されなくなり、ログアウトのリンクが表示される' do
@@ -70,7 +70,7 @@ RSpec.feature 'Sessions', type: :feature, js: true do
       before { page.driver.browser.switch_to.alert.accept }
       it 'ログイン画面に遷移する'
       # expect(page).to have_content 'ログイン'
-      context 'ログアウトした後'do
+      context 'ログアウトした後' do
         before { visit tasks_path }
         it 'ログアウトのリンクが表示されなくなり、ログインのリンクが表示される' do
           expect(page).not_to have_selector 'a#logout_link', text: 'ログアウト'
@@ -80,7 +80,7 @@ RSpec.feature 'Sessions', type: :feature, js: true do
     end
     context '確認ダイアログでNoを押した場合' do
       before { page.driver.browser.switch_to.alert.dismiss }
-      # it '画面は変わらない'
+      it '画面は変わらない'
       #   expect(current_path).to eq tasks_path
       it 'ログアウトのリンクが表示され、ログインのリンクは表示されない' do
         expect(page).not_to have_selector 'a#login_link', text: 'ログイン'

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -19,6 +19,13 @@ RSpec.feature 'Sessions', type: :feature, js: true do
       end
       it 'タスク一覧画面に遷移する'
         # expect(page).to have_selector '#title_log'
+      context 'ログインした後' do
+        before { visit tasks_path }
+        it 'ログインのリンクが表示されなくなり、ログアウトのリンクが表示される' do
+          expect(page).not_to have_selector 'a#login_link', text: 'ログイン'
+          expect(page).to have_selector 'a#logout_link', text: 'ログアウト'
+        end
+      end
     end
     context '登録されているユーザーとアカウントIDとパスワードが異なる場合' do
       before do
@@ -38,6 +45,13 @@ RSpec.feature 'Sessions', type: :feature, js: true do
         end
         it 'タスク一覧画面に遷移する'
           # expect(page).to have_content 'タスク一覧'
+        context 'ログインした後' do
+          before { visit tasks_path }
+          it 'ログインのリンクが表示されなくなり、ログアウトのリンクが表示される' do
+            expect(page).not_to have_selector 'a#login_link', text: 'ログイン'
+            expect(page).to have_selector 'a#logout_link', text: 'ログアウト'
+          end
+        end
       end
     end
   end

--- a/spec/requests/sessions_spec.rb
+++ b/spec/requests/sessions_spec.rb
@@ -89,8 +89,8 @@ RSpec.describe 'Session', type: :request do
       it 'レスポンスからユーザーの記憶トークンが取り除かれる' do
         expect(response.cookies['user_token']).to eq nil
       end
-      it 'レスポンスでログアウト成功を伝えるメッセージが返る' do
-        expect(response.body).to eq 'ログアウトに成功しました'
+      it 'レスポンスでログアウト後、遷移する画面のURLが返る' do
+        expect(response.body).to eq '/login'
       end
     end
   end


### PR DESCRIPTION
## やったこと
- ログインしている場合`ログアウト`、ログインしていない場合`ログイン`のリンクがヘッダーに表示される様にする
- ログアウトのリンクを押すと、確認ダイアログを表示し、yesを選んだ場合ログアウトする様にした
  - ブラウザに保存されたユーザーのクッキー情報を削除する
  - ログアウトしたユーザーのhashed_cookie_tokenを削除する

## 関連するissue
close #38 