### PR TITLE
タスクの更新に失敗した場合のテストケースを追加

### DIFF
--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -280,8 +280,30 @@ RSpec.feature 'Tasks', type: :feature, js: true do
             fill_in 'task_title', with: 'タスクの更新'
             click_button '更新する'
           end
-          it '作成したタスクの更新する' do
+          it 'タスクの更新に成功する' do
             expect(page).to have_content 'タスクの内容が更新されました'
+          end
+        end
+        context 'タスクのタイトルを30文字以上にしてしまった場合' do
+          before do
+            click_link '編集'
+            fill_in 'task_title', with: '12345678910/123456778910/12345678910/'
+            click_button '更新する'
+          end
+          it 'タスクの更新に失敗する' do
+            expect(page).to have_content 'タスクの更新に失敗しました'
+          end
+        end
+        context '期限をタスク更新日より前に設定してしまった場合' do
+          before do
+            click_link '編集'
+            select '2019', from: 'task_dead_line_on_1i'
+            select '1月', from: 'task_dead_line_on_2i'
+            select '1', from: 'task_dead_line_on_3i'
+            click_button '更新する'
+          end
+          it 'タスクの更新に失敗する' do
+            expect(page).to have_content 'タスクの更新に失敗しました'
           end
         end
       end


### PR DESCRIPTION
## やったこと
- テストできていなかった箇所のテストケースを追加
- feature_specからrequest_specに移行する際、動作を保証するテストが必要と考え実装

## code coverageの変化
- テストを追加する前
![image](https://user-images.githubusercontent.com/31206922/59730500-97fcb880-927d-11e9-9070-6567568a1d8a.png)


- テストを追加した後
![スクリーンショット 2019-06-19 10 25 34](https://user-images.githubusercontent.com/31206922/59730442-5966fe00-927d-11e9-9111-abf38a837325.png)
