### PR TITLE
絞り込み検索のテストをrequest_specで行えるようにする

### DIFF
--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -126,48 +126,6 @@ RSpec.feature 'Tasks', type: :feature, js: true do
           end
         end
       end
-
-      describe '絞り込み検索' do
-        before { click_button '検索条件をリセット' }
-        context 'タイトル名でのみ検索する場合' do
-          before do
-            fill_in 'query', with: 'Test2'
-            click_button '検索'
-          end
-          it '検索文言とタイトル名が部分一致するタスクのみ表示される' do
-            expect(page).to have_selector 'tr.tasks', count: 1
-            within all('tr.tasks')[0] do
-              expect(find('th.title')).to have_content 'Test2'
-            end
-          end
-        end
-        context 'ステータスのみで検索する場合' do
-          before do
-            select '着手', from: 'status'
-            click_button '検索'
-          end
-          it '同じステータスのタスクのみが表示される' do
-            expect(page).to have_selector 'tr.tasks', count: 1
-            within all('tr.tasks')[0] do
-              expect(find('th.status')).to have_content '着手'
-            end
-          end
-        end
-        context 'タイトル名とステータスで検索する場合' do
-          before do
-            fill_in 'query', with: 'Test1'
-            select '着手', from: 'status'
-            click_button '検索'
-          end
-          it '検索文言とタイトル名が部分一致した上でステータスが同じタスクのみが表示される' do
-            expect(page).to have_selector 'tr.tasks', count: 1
-            within all('tr.tasks')[0] do
-              expect(find('th.title')).to have_content 'Test1'
-              expect(find('th.status')).to have_content '着手'
-            end
-          end
-        end
-      end
     end
 
     describe 'タスクの投稿' do

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -9,17 +9,21 @@ RSpec.describe 'Api::Tasks', type: :request do
       accountid: 'tester',
       password: 'IamTestMan'
     }
-    2.times { create(:task, title: 'login_userd_task', user: user) }
-    3.times { create(:task) }
   end
   describe 'GET#index' do
     context 'ログインを行なっている場合' do
-      it '自分が投稿したタスクのみが表示される' do
-        get api_tasks_path
-        login_user_tasks = JSON.parse(response.body)['nested']['data']
-        expect(login_user_tasks.length).to eq 2
-        expect(login_user_tasks[0]['title']).to eq 'login_userd_task'
-        expect(login_user_tasks[1]['title']).to eq 'login_userd_task'
+      context '絞り込み検索を行わない場合' do
+        before do
+          2.times { create(:task, title: 'login_userd_task', user: user) }
+          3.times { create(:task) }
+        end
+        it '自分が投稿したタスクのみが表示される' do
+          get api_tasks_path
+          login_user_tasks = JSON.parse(response.body)['nested']['data']
+          expect(login_user_tasks.length).to eq 2
+          expect(login_user_tasks[0]['title']).to eq 'login_userd_task'
+          expect(login_user_tasks[1]['title']).to eq 'login_userd_task'
+        end
       end
     end
   end

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -25,6 +25,50 @@ RSpec.describe 'Api::Tasks', type: :request do
           expect(login_user_tasks[1]['title']).to eq 'login_userd_task'
         end
       end
+      context '絞り込み検索を行う場合' do
+        let!(:task_for_title_search) { create(:task, title: 'search_test', status: 'completed', user: user) }
+        let!(:task_for_status_search) { create(:task, title: 'not_matching', status: 'working', user: user) }
+        let!(:same_title_status_task) { create(:task, title: 'search', status: 'working', user: user) }
+        let(:title) { '' }
+        let(:status) { '' }
+        let(:search_request) do
+          get api_tasks_path, params: {
+            title: title,
+            status: status
+          }
+        end
+        context 'タスク名でのみ検索する場合' do
+          let(:title) { 'search' }
+          it '検索文言とタイトル名が部分一致するタスクのみ表示される' do
+            search_request
+            searched_tasks = JSON.parse(response.body)['nested']['data']
+            expect(searched_tasks.length).to eq 2
+            expect(searched_tasks[0]['title']).to include title
+            expect(searched_tasks[1]['title']).to include title
+          end
+        end
+        context 'ステータスのみで検索する場合' do
+          let(:status) { 'working' }
+          it '同じステータスのタスクのみが表示される' do
+            search_request
+            searched_tasks = JSON.parse(response.body)['nested']['data']
+            expect(searched_tasks.length).to eq 2
+            expect(searched_tasks[0]['status']['text']).to eq '着手'
+            expect(searched_tasks[1]['status']['text']).to eq '着手'
+          end
+        end
+        context 'タスク名とステータスで検索する場合' do
+          let(:title) { 'search' }
+          let(:status) { 'working' }
+          it '検索文言とタイトル名が部分一致した上でステータスが同じタスクのみ表示される' do
+            search_request
+            searched_tasks = JSON.parse(response.body)['nested']['data']
+            expect(searched_tasks.length).to eq 1
+            expect(searched_tasks[0]['title']).to include title
+            expect(searched_tasks[0]['status']['text']).to eq '着手'
+          end
+        end
+      end
     end
   end
 end

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -16,10 +16,10 @@ RSpec.describe 'Api::Tasks', type: :request do
         before do
           2.times { create(:task, title: 'login_userd_task', user: user) }
           3.times { create(:task) }
-        end
-        it '自分が投稿したタスクのみが表示される' do
           get api_tasks_path
-          login_user_tasks = JSON.parse(response.body)['nested']['data']
+        end
+        let(:login_user_tasks) { JSON.parse(response.body)['nested']['data'] }
+        it '自分が投稿したタスクのみが表示される' do
           expect(login_user_tasks.length).to eq 2
           expect(login_user_tasks[0]['title']).to eq 'login_userd_task'
           expect(login_user_tasks[1]['title']).to eq 'login_userd_task'
@@ -39,9 +39,9 @@ RSpec.describe 'Api::Tasks', type: :request do
         end
         context 'タスク名でのみ検索する場合' do
           let(:title) { 'search' }
+          before { search_request }
+          let(:searched_tasks) { JSON.parse(response.body)['nested']['data']  }
           it '検索文言とタイトル名が部分一致するタスクのみ表示される' do
-            search_request
-            searched_tasks = JSON.parse(response.body)['nested']['data']
             expect(searched_tasks.length).to eq 2
             expect(searched_tasks[0]['title']).to include title
             expect(searched_tasks[1]['title']).to include title
@@ -49,9 +49,9 @@ RSpec.describe 'Api::Tasks', type: :request do
         end
         context 'ステータスのみで検索する場合' do
           let(:status) { 'working' }
+          before { search_request }
+          let(:searched_tasks) { JSON.parse(response.body)['nested']['data']  }
           it '同じステータスのタスクのみが表示される' do
-            search_request
-            searched_tasks = JSON.parse(response.body)['nested']['data']
             expect(searched_tasks.length).to eq 2
             expect(searched_tasks[0]['status']['text']).to eq '着手'
             expect(searched_tasks[1]['status']['text']).to eq '着手'
@@ -60,9 +60,9 @@ RSpec.describe 'Api::Tasks', type: :request do
         context 'タスク名とステータスで検索する場合' do
           let(:title) { 'search' }
           let(:status) { 'working' }
+          before { search_request }
+          let(:searched_tasks) { JSON.parse(response.body)['nested']['data']  }
           it '検索文言とタイトル名が部分一致した上でステータスが同じタスクのみ表示される' do
-            search_request
-            searched_tasks = JSON.parse(response.body)['nested']['data']
             expect(searched_tasks.length).to eq 1
             expect(searched_tasks[0]['title']).to include title
             expect(searched_tasks[0]['status']['text']).to eq '着手'

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -40,7 +40,7 @@ RSpec.describe 'Api::Tasks', type: :request do
         context 'タスク名でのみ検索する場合' do
           let(:title) { 'search' }
           before { search_request }
-          let(:searched_tasks) { JSON.parse(response.body)['nested']['data']  }
+          let(:searched_tasks) { JSON.parse(response.body)['nested']['data'] }
           it '検索文言とタイトル名が部分一致するタスクのみ表示される' do
             expect(searched_tasks.length).to eq 2
             expect(searched_tasks[0]['title']).to include title
@@ -50,7 +50,7 @@ RSpec.describe 'Api::Tasks', type: :request do
         context 'ステータスのみで検索する場合' do
           let(:status) { 'working' }
           before { search_request }
-          let(:searched_tasks) { JSON.parse(response.body)['nested']['data']  }
+          let(:searched_tasks) { JSON.parse(response.body)['nested']['data'] }
           it '同じステータスのタスクのみが表示される' do
             expect(searched_tasks.length).to eq 2
             expect(searched_tasks[0]['status']['text']).to eq '着手'
@@ -61,7 +61,7 @@ RSpec.describe 'Api::Tasks', type: :request do
           let(:title) { 'search' }
           let(:status) { 'working' }
           before { search_request }
-          let(:searched_tasks) { JSON.parse(response.body)['nested']['data']  }
+          let(:searched_tasks) { JSON.parse(response.body)['nested']['data'] }
           it '検索文言とタイトル名が部分一致した上でステータスが同じタスクのみ表示される' do
             expect(searched_tasks.length).to eq 1
             expect(searched_tasks[0]['title']).to include title


### PR DESCRIPTION
## やったこと
- feature_specで行なっていたタスクを検索する機能のテストをrequest_specで行えるようにする

## coverageの変化
- feature_specに書いていたテストを消した後
![スクリーンショット 2019-06-19 16 11 57](https://user-images.githubusercontent.com/31206922/59745516-f5a9f880-92af-11e9-966a-d37aa58a9e5f.png)

- feature_specに書いていたテストをrequest_specに置き換えた後
![スクリーンショット 2019-06-19 16 15 01](https://user-images.githubusercontent.com/31206922/59745549-065a6e80-92b0-11e9-87a5-41270eadb41d.png)
