### PR TITLE
タスクの削除をapiサーバーにリクエストを投げて行うようにする

### DIFF
--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -2,6 +2,7 @@
 
 class Api::TasksController < ApplicationController # rubocop:disable Style/ClassAndModuleChildren
   SUCCESS_URL_AFTER_ALL_ACTION = '/tasks'
+  rescue_from ActiveRecord::RecordNotFound, with: :render_not_found_error_message_and_status
   before_action :set_task, only: %i(destroy)
   include SessionsHelper
 
@@ -35,7 +36,9 @@ class Api::TasksController < ApplicationController # rubocop:disable Style/Class
 
   def set_task
     @task = Task.find(params[:id])
-  rescue ActiveRecord::RecordNotFound
+  end
+
+  def render_not_found_error_message_and_status
     render json: '選択したタスクが見つかりませんでした', status: 404
   end
 end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -1,8 +1,10 @@
 # frozen_string_literal: true
 
 class Api::TasksController < ApplicationController # rubocop:disable Style/ClassAndModuleChildren
-  CREATE_SUCCESS_URL = '/tasks'
+  SUCCESS_URL_AFTER_ALL_ACTION = '/tasks'
+  before_action :set_task, only: %i(destroy)
   include SessionsHelper
+
   def index
     @tasks = if params[:title] || params[:status]
                current_user.tasks.search(params[:title], params[:status]).orderd_by(:desc).page(params[:page]).per(10)
@@ -14,15 +16,24 @@ class Api::TasksController < ApplicationController # rubocop:disable Style/Class
   def create
     @task = current_user.tasks.new(task_params)
     if @task.save
-      render json: { task: @task, redirect_url: CREATE_SUCCESS_URL }, status: 200
+      render json: { task: @task, redirect_url: SUCCESS_URL_AFTER_ALL_ACTION }, status: 200
     else
       render json: @task.errors.full_messages, status: 400
     end
+  end
+
+  def destroy
+    @task.destroy
+    render json: SUCCESS_URL_AFTER_ALL_ACTION, status: 200
   end
 
   private
 
   def task_params
     params.permit(:title, :importance, :dead_line_on, :status, :detail, :user_id)
+  end
+
+  def set_task
+    @task = Task.find(params[:id])
   end
 end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -35,5 +35,7 @@ class Api::TasksController < ApplicationController # rubocop:disable Style/Class
 
   def set_task
     @task = Task.find(params[:id])
+  rescue ActiveRecord::RecordNotFound
+    render json: '選択したタスクが見つかりませんでした', status: 404
   end
 end

--- a/app/controllers/api/tasks_controller.rb
+++ b/app/controllers/api/tasks_controller.rb
@@ -1,10 +1,12 @@
 # frozen_string_literal: true
 
 class Api::TasksController < ApplicationController # rubocop:disable Style/ClassAndModuleChildren
-  SUCCESS_URL_AFTER_ALL_ACTION = '/tasks'
-  rescue_from ActiveRecord::RecordNotFound, with: :render_not_found_error_message_and_status
-  before_action :set_task, only: %i(destroy)
   include SessionsHelper
+
+  rescue_from ActiveRecord::RecordNotFound, with: :render_not_found_error_message_and_status
+
+  before_action :set_task, only: %i(destroy)
+  REDIRECT_URL_AFTER_CREATE_UPDATE_DESTROY = '/tasks'
 
   def index
     @tasks = if params[:title] || params[:status]
@@ -17,7 +19,7 @@ class Api::TasksController < ApplicationController # rubocop:disable Style/Class
   def create
     @task = current_user.tasks.new(task_params)
     if @task.save
-      render json: { task: @task, redirect_url: SUCCESS_URL_AFTER_ALL_ACTION }, status: 200
+      render json: { task: @task, redirect_url: REDIRECT_URL_AFTER_CREATE_UPDATE_DESTROY }, status: 200
     else
       render json: @task.errors.full_messages, status: 400
     end
@@ -25,7 +27,7 @@ class Api::TasksController < ApplicationController # rubocop:disable Style/Class
 
   def destroy
     @task.destroy
-    render json: SUCCESS_URL_AFTER_ALL_ACTION, status: 200
+    render json: REDIRECT_URL_AFTER_CREATE_UPDATE_DESTROY, status: 200
   end
 
   private

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -2,7 +2,7 @@
 
 class TasksController < ApplicationController
   include SessionsHelper
-  before_action :set_task, only: %i(show edit update destroy)
+  before_action :set_task, only: %i(show edit update)
   before_action :require_login
 
   def index; end
@@ -17,12 +17,6 @@ class TasksController < ApplicationController
       flash.now[:danger] = 'タスクの更新に失敗しました'
       render :edit
     end
-  end
-
-  def destroy
-    @task.destroy
-    flash[:success] = 'タスクを削除しました'
-    redirect_to tasks_path
   end
 
   private

--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -10,7 +10,7 @@ window.tasks = new Vue({
   el: '#all_tasks',
   data: {
     method: 'get',
-    request_url: '/api/tasks',
+    request_url: '/api/tasks/',
     tasks: [],
     options: {
       remote_data: 'nested.data',
@@ -89,6 +89,18 @@ window.tasks = new Vue({
     },
     updateResource: function(data) {
       this.tasks = data;
+    },
+    deleteTask: function(id) {
+      if (window.confirm('選択したタスクを削除しますか')) {
+        requestByConfiguredAxios({
+          method: 'delete',
+          url: this.request_url + id,
+          withCsrf: true,
+          withCookie: true}
+        ).then((response)=> {
+          window.location.href = response.data;
+        });
+      }
     },
   },
   created: function() {

--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -1,6 +1,7 @@
 import Vue from 'vue/dist/vue.esm.js';
 import axios from 'axios';
 import requestByConfiguredAxios from '../modules/request_by_configured_axios';
+import toastr from 'toastr';
 import VuePaginator from 'vuejs-paginator';
 import _ from 'lodash';
 
@@ -99,6 +100,8 @@ window.tasks = new Vue({
           withCookie: true}
         ).then((response)=> {
           window.location.href = response.data;
+        }).catch((error)=> {
+          toastr(error.response.data);
         });
       }
     },

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -43,7 +43,10 @@
           th.dead_line_on scope="row" = "{{task.dead_line_on}}"
           th.detail scope="row" = "{{task.detail}}"
           th.created_day scope="row" = "{{task.created_at}}"
-          th.each_task_link
-            a v-bind:href='"/tasks/" + task.id' 詳細
+          th.each_task_links
+            .each_task_detail_link
+              a v-bind:href='"/tasks/" + task.id' 詳細
+            .each_task_delete_link
+              a data-method="delete" v-bind:href='"/api/tasks/" + task.id' v-on:click.prevent.stop='deleteTask(task.id)' 削除
       v-paginator#paginator v-bind:options="options" resource_url="/api/tasks" v-on:update="updateResource"
 = javascript_pack_tag 'tasks/index_vue'

--- a/app/views/tasks/show.html.slim
+++ b/app/views/tasks/show.html.slim
@@ -4,6 +4,5 @@
   .task_head
     p #{@task.title} #{@task.importance} #{@task.status} #{@task.dead_line_on}
     span = link_to "編集", edit_task_path(@task.id)
-    span = link_to "削除", task_path(@task.id), method: :delete, data: { confirm: '本当に削除しますか？' }
   .task_detail
     p #{@task.detail}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,13 +4,13 @@ Rails.application.routes.draw do
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 
   root to: 'tasks#index'
-  resources :tasks, except: :create
+  resources :tasks, except: %i(create destroy)
 
   get 'login', to: 'sessions#new'
   post 'login', to: 'sessions#create'
   delete 'logout', to: 'sessions#destroy'
 
   namespace :api, format: 'json' do
-    resources :tasks, only: %i(index create)
+    resources :tasks, only: %i(index create destroy)
   end
 end

--- a/spec/features/tasks_spec.rb
+++ b/spec/features/tasks_spec.rb
@@ -195,22 +195,6 @@ RSpec.feature 'Tasks', type: :feature, js: true do
           end
         end
       end
-
-      describe '削除' do
-        before { click_link '削除' }
-        context '確認時、Yesを選んだ場合' do
-          before { page.driver.browser.switch_to.alert.accept }
-          it '削除される' do
-            expect(page).to have_content 'タスクを削除しました'
-          end
-        end
-        context '確認時、Noを選んだ場合' do
-          before { page.driver.browser.switch_to.alert.dismiss }
-          it '削除されない' do
-            expect(page).to have_content 'タスクの詳細'
-          end
-        end
-      end
     end
   end
   context 'ログインしていない場合' do

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -122,10 +122,9 @@ RSpec.describe 'Api::Tasks', type: :request do
     end
   end
   describe 'DELETE#destroy' do
-    let!(:created_task) { create(:task, user: user) }
-    let(:task_delete_request) { delete api_task_path(created_task.id) }
     context 'タスクの削除に成功した場合' do
-      before { task_delete_request }
+      let!(:created_task) { create(:task, user: user) }
+      before { delete api_task_path(created_task.id) }
       it '削除後、遷移先の画面のURLがレスポンスで返る' do
         expect(response.body).to eq '/tasks'
       end
@@ -134,10 +133,11 @@ RSpec.describe 'Api::Tasks', type: :request do
       end
     end
     context 'タスクの削除に失敗した場合' do
+      let!(:task_for_failed_test_case) { create(:task, user: user) }
       context '削除しようとしたタスクが見つからなかった場合' do
         before do
-          created_task.destroy
-          task_delete_request
+          task_for_failed_test_case.destroy
+          delete api_task_path(task_for_failed_test_case.id)
         end
         it 'エラーメッセージを返す' do
           expect(response.body).to eq '選択したタスクが見つかりませんでした'

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -121,4 +121,16 @@ RSpec.describe 'Api::Tasks', type: :request do
       end
     end
   end
+  describe 'DELETE#destroy' do
+    let!(:created_task) { create(:task, user: user) }
+    before { delete api_task_path(created_task.id) }
+    context 'タスクの削除に成功した場合' do
+      it '削除後、遷移先の画面のURLがレスポンスで返る' do
+        expect(response.body).to eq '/tasks'
+      end
+      it '200のステータスが返る' do
+        expect(response.status).to eq 200
+      end
+    end
+  end
 end

--- a/spec/requests/api/tasks_spec.rb
+++ b/spec/requests/api/tasks_spec.rb
@@ -123,13 +123,28 @@ RSpec.describe 'Api::Tasks', type: :request do
   end
   describe 'DELETE#destroy' do
     let!(:created_task) { create(:task, user: user) }
-    before { delete api_task_path(created_task.id) }
+    let(:task_delete_request) { delete api_task_path(created_task.id) }
     context 'タスクの削除に成功した場合' do
+      before { task_delete_request }
       it '削除後、遷移先の画面のURLがレスポンスで返る' do
         expect(response.body).to eq '/tasks'
       end
       it '200のステータスが返る' do
         expect(response.status).to eq 200
+      end
+    end
+    context 'タスクの削除に失敗した場合' do
+      context '削除しようとしたタスクが見つからなかった場合' do
+        before do
+          created_task.destroy
+          task_delete_request
+        end
+        it 'エラーメッセージを返す' do
+          expect(response.body).to eq '選択したタスクが見つかりませんでした'
+        end
+        it '404のステータスが返る' do
+          expect(response.status).to eq 404
+        end
       end
     end
   end


### PR DESCRIPTION
![タスクの削除を非同期で行えるようにする](https://user-images.githubusercontent.com/31206922/59911790-b1555e80-944f-11e9-84f3-0aaa14b314dd.gif)

## やったこと
- 作成したタスクの削除を非同期で行えるようにする
- タスクの削除のテストをfeature_specからrequest_specに移す
