### PR TITLE
fix: toastrを使わずにエラー表示を行なっていた箇所でtoastrを使うようにする

### DIFF
--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -69,7 +69,7 @@ window.tasks = new Vue({
       ).then((response)=> {
         this.tasks = response.data.nested.data;
       }).catch(function(e) {
-        alert(e);
+        toastr(e);
       });
     },
     getTasks: function() {
@@ -80,7 +80,7 @@ window.tasks = new Vue({
       ).then((response)=> {
         this.tasks = response.data.nested.data;
       }).catch((e)=> {
-        alert(e);
+        toastr(e);
       });
     },
     reset: function() {

--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -68,8 +68,8 @@ window.tasks = new Vue({
                                 withCookie: true}
       ).then((response)=> {
         this.tasks = response.data.nested.data;
-      }).catch(function(e) {
-        toastr(e);
+      }).catch(()=> {
+        toastr.error('通信中にエラーが発生しました');
       });
     },
     getTasks: function() {
@@ -79,8 +79,8 @@ window.tasks = new Vue({
                                 withCookie: true}
       ).then((response)=> {
         this.tasks = response.data.nested.data;
-      }).catch((e)=> {
-        toastr(e);
+      }).catch(()=> {
+        toastr.error('通信中にエラーが発生しました');
       });
     },
     reset: function() {


### PR DESCRIPTION
## やったこと
- toastrを使わずにエラー表示を行なっていた箇所でも、toastrでエラーを出すように変更

<img width="1316" alt="スクリーンショット 2019-06-26 15 59 54" src="https://user-images.githubusercontent.com/31206922/60158293-c48b7400-982b-11e9-8c90-f406a8a50c17.png">

close #124