### PR TITLE
ログアウト時、確認ダイアログでNoを選んでもログアウトしていた不具合を修正

### DIFF
--- a/app/javascript/packs/sessions/logout_vue.js
+++ b/app/javascript/packs/sessions/logout_vue.js
@@ -11,9 +11,9 @@ window.logoutLink = new Vue({
     requestLogout: function() {
       if (window.confirm('ログアウトしますか？')) {
         requestByConfiguredAxios({method: this.method,
-          url: this.request_url,
-          withCsrf: true,
-          withCookie: true}
+                                  url: this.request_url,
+                                  withCsrf: true,
+                                  withCookie: true}
         ).then((response)=> {
           window.location.href = response.data;
         });

--- a/app/javascript/packs/sessions/logout_vue.js
+++ b/app/javascript/packs/sessions/logout_vue.js
@@ -9,13 +9,15 @@ window.logoutLink = new Vue({
   },
   methods: {
     requestLogout: function() {
-      requestByConfiguredAxios({method: this.method,
-                                url: this.request_url,
-                                withCsrf: true,
-                                withCookie: true}
-      ).then((response)=> {
-        window.location.href = response.data;
-      });
+      if (window.confirm('ログアウトしますか？')) {
+        requestByConfiguredAxios({method: this.method,
+          url: this.request_url,
+          withCsrf: true,
+          withCookie: true}
+        ).then((response)=> {
+          window.location.href = response.data;
+        });
+      }
     },
   },
 });

--- a/app/views/layouts/_header.slim
+++ b/app/views/layouts/_header.slim
@@ -7,7 +7,7 @@ nav.navbar.navbar-expand-lg.application_header
     li.nav-item
       = link_to "タスクの投稿", new_task_path, class: "nav-link"
     li.nav-item
-      = link_to "ログアウト", logout_path, method: :delete, 'v-on:click.prevent': 'requestLogout', class: "nav-link", id: "logout_link", data: { confirm: 'ログアウトしますか？' } if logged_in?
+      = link_to "ログアウト", logout_path, method: :delete, 'v-on:click.prevent.stop': 'requestLogout', class: "nav-link", id: "logout_link" if logged_in?
       = link_to "ログイン", login_path, class: "nav-link", id: 'login_link' unless logged_in?
 
 = javascript_pack_tag 'sessions/logout_vue'

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -69,7 +69,7 @@ RSpec.feature 'Sessions', type: :feature, js: true do
       it 'ログイン画面に遷移する'
       context 'ログアウトした後' do
         before { visit tasks_path }
-        it 'ログアウトのリンクが表示されなくなり、ログインのリンクが表示される' 
+        it 'ログアウトのリンクが表示されなくなり、ログインのリンクが表示される'
       end
     end
     context '確認ダイアログでNoを押した場合' do

--- a/spec/features/sessions_spec.rb
+++ b/spec/features/sessions_spec.rb
@@ -69,10 +69,7 @@ RSpec.feature 'Sessions', type: :feature, js: true do
       it 'ログイン画面に遷移する'
       context 'ログアウトした後' do
         before { visit tasks_path }
-        it 'ログアウトのリンクが表示されなくなり、ログインのリンクが表示される' do
-          expect(page).not_to have_selector 'a#logout_link', text: 'ログアウト'
-          expect(page).to have_selector 'a#login_link', text: 'ログイン'
-        end
+        it 'ログアウトのリンクが表示されなくなり、ログインのリンクが表示される' 
       end
     end
     context '確認ダイアログでNoを押した場合' do


### PR DESCRIPTION
変更前の動画
![意味のないconfirm](https://user-images.githubusercontent.com/31206922/59901599-bc4fc500-9436-11e9-8f23-ccbb8625cab8.gif)


変更後の動画
![ログアウト機能の修正](https://user-images.githubusercontent.com/31206922/60159900-24cfe500-982f-11e9-8dea-1786a3951263.gif)


## やったこと
- ログアウトの際、確認ダイアログでYesを選ぶと、リクエストが2回飛んでいたので修正
- ログアウトの際、確認ダイアログで Noを選んでもログアウトするバグを修正

close  #117 
close #123 