### PR TITLE
タスクを並び替えた後、編集フォームの表示が上手く行われなかったので修正

### DIFF
--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -36,7 +36,7 @@
           th.head scope="col" = t("actionview.task.index.detail")
           th.head scope="col" = t("actionview.task.index.created_at_day")
           th.head scope="col" = t("actionview.task.index.option")
-        tr.tasks v-for="task in tasks"
+        tr.tasks v-for="task in tasks" v-bind:key="task.id"
           th.title scope="row" = "{{task.title}}"
           th.importance scope="row" = "{{task.importance.text}}"
           th.status scope="row" = "{{task.status.text}}"


### PR DESCRIPTION

![並び替えをした後の編集フォームの表示](https://user-images.githubusercontent.com/31206922/60229192-0cfc6d80-98d0-11e9-94db-13bc6660bcf1.gif)


## やったこと
  - タスクを並び替えた後、編集フォームのコンポーネントもきちんと並びかわるように修正

参考にしたサイト
https://jp.vuejs.org/v2/guide/list.html#%E7%8A%B6%E6%85%8B%E3%81%AE%E7%B6%AD%E6%8C%81
https://ja.stackoverflow.com/questions/42250/v-bindkey-%E3%82%92%E4%BD%BF%E3%81%86%E6%99%82%E3%81%A8%E4%BD%BF%E3%82%8F%E3%81%AA%E3%81%84%E6%99%82%E3%81%AE%E9%81%95%E3%81%84