### PR TITLE
タスクを一覧表示しているテーブルをvue-materialのコンポーネントに置き換える

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -7,6 +7,3 @@
 @import "animation/delayed_flake";
 @import "common";
 @import "material_design_fonts_icon";
-@import "../../../node_modules/toastr/toastr";
-@import "../../../node_modules/vue-material/dist/vue-material";
-@import "../../../node_modules/vue-material/dist/theme/default";

--- a/app/javascript/packs/modules/task_form_requestable.js
+++ b/app/javascript/packs/modules/task_form_requestable.js
@@ -1,6 +1,6 @@
 import requestByConfiguredAxios from './request_by_configured_axios';
 import toastr from 'toastr';
-import "toastr/toastr.scss";
+import 'toastr/toastr.scss';
 
 export default {
   data: function() {

--- a/app/javascript/packs/modules/task_form_requestable.js
+++ b/app/javascript/packs/modules/task_form_requestable.js
@@ -1,5 +1,6 @@
 import requestByConfiguredAxios from './request_by_configured_axios';
 import toastr from 'toastr';
+import "toastr/toastr.scss";
 
 export default {
   data: function() {

--- a/app/javascript/packs/sessions/sessions_vue.js
+++ b/app/javascript/packs/sessions/sessions_vue.js
@@ -2,6 +2,8 @@ import Vue from 'vue/dist/vue.esm.js';
 import requestByConfiguredAxios from '../modules/request_by_configured_axios';
 import toastr from 'toastr';
 import {MdButton, MdField} from 'vue-material/dist/components';
+import "toastr/toastr.scss";
+import '../../stylesheets/application.scss';
 
 Vue.use(MdButton);
 Vue.use(MdField);

--- a/app/javascript/packs/sessions/sessions_vue.js
+++ b/app/javascript/packs/sessions/sessions_vue.js
@@ -2,7 +2,7 @@ import Vue from 'vue/dist/vue.esm.js';
 import requestByConfiguredAxios from '../modules/request_by_configured_axios';
 import toastr from 'toastr';
 import {MdButton, MdField} from 'vue-material/dist/components';
-import "toastr/toastr.scss";
+import 'toastr/toastr.scss';
 import '../../stylesheets/application.scss';
 
 Vue.use(MdButton);

--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -3,12 +3,15 @@ import axios from 'axios';
 import requestByConfiguredAxios from '../modules/request_by_configured_axios';
 import toastr from 'toastr';
 import updateTaskForm from '../modules/update_task_form_component.js';
+import VueMaterial from 'vue-material';
 import VuePaginator from 'vuejs-paginator';
 import _ from 'lodash';
 import "toastr/toastr.scss";
 import '../../stylesheets/application.scss';
 
 Vue.prototype.$http = axios;
+
+Vue.use(VueMaterial);
 
 window.tasks = new Vue({
   el: '#all_tasks',

--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 import requestByConfiguredAxios from '../modules/request_by_configured_axios';
 import toastr from 'toastr';
 import updateTaskForm from '../modules/update_task_form_component.js';
-import VueMaterial from 'vue-material';
+import {MdTable} from 'vue-material/dist/components';
 import VuePaginator from 'vuejs-paginator';
 import _ from 'lodash';
 import 'toastr/toastr.scss';
@@ -11,7 +11,7 @@ import '../../stylesheets/application.scss';
 
 Vue.prototype.$http = axios;
 
-Vue.use(VueMaterial);
+Vue.use(MdTable);
 
 window.tasks = new Vue({
   el: '#all_tasks',

--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -5,6 +5,8 @@ import toastr from 'toastr';
 import updateTaskForm from '../modules/update_task_form_component.js';
 import VuePaginator from 'vuejs-paginator';
 import _ from 'lodash';
+import "toastr/toastr.scss";
+import '../../stylesheets/application.scss';
 
 Vue.prototype.$http = axios;
 

--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -6,7 +6,7 @@ import updateTaskForm from '../modules/update_task_form_component.js';
 import VueMaterial from 'vue-material';
 import VuePaginator from 'vuejs-paginator';
 import _ from 'lodash';
-import "toastr/toastr.scss";
+import 'toastr/toastr.scss';
 import '../../stylesheets/application.scss';
 
 Vue.prototype.$http = axios;

--- a/app/javascript/packs/tasks/index_vue.js
+++ b/app/javascript/packs/tasks/index_vue.js
@@ -3,7 +3,7 @@ import axios from 'axios';
 import requestByConfiguredAxios from '../modules/request_by_configured_axios';
 import toastr from 'toastr';
 import updateTaskForm from '../modules/update_task_form_component.js';
-import {MdTable} from 'vue-material/dist/components';
+import {MdContent, MdRipple, MdTable} from 'vue-material/dist/components';
 import VuePaginator from 'vuejs-paginator';
 import _ from 'lodash';
 import 'toastr/toastr.scss';
@@ -11,6 +11,8 @@ import '../../stylesheets/application.scss';
 
 Vue.prototype.$http = axios;
 
+Vue.use(MdRipple);
+Vue.use(MdContent);
 Vue.use(MdTable);
 
 window.tasks = new Vue({

--- a/app/javascript/stylesheets/_configured_vue-material_theme.scss
+++ b/app/javascript/stylesheets/_configured_vue-material_theme.scss
@@ -1,7 +1,0 @@
-@import "~vue-material/dist/theme/engine";
-
-@include md-register-theme("default", (
-        background: #f9f1f4
-));
-
-@import "~vue-material/dist/theme/all";

--- a/app/javascript/stylesheets/_configured_vue-material_theme.scss
+++ b/app/javascript/stylesheets/_configured_vue-material_theme.scss
@@ -1,0 +1,7 @@
+@import "~vue-material/dist/theme/engine";
+
+@include md-register-theme("default", (
+        background: #f9f1f4
+));
+
+@import "~vue-material/dist/theme/all";

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,2 +1,2 @@
 @import "~vue-material/dist/vue-material";
-@import "configured_vue-material_theme";
+@import "custom_themes/spring_vue-material-component_theme";

--- a/app/javascript/stylesheets/application.scss
+++ b/app/javascript/stylesheets/application.scss
@@ -1,0 +1,2 @@
+@import "~vue-material/dist/vue-material";
+@import "configured_vue-material_theme";

--- a/app/javascript/stylesheets/custom_themes/_spring_vue-material-component_theme.scss
+++ b/app/javascript/stylesheets/custom_themes/_spring_vue-material-component_theme.scss
@@ -1,0 +1,7 @@
+@import "../../../../node_modules/vue-material/dist/theme/engine";
+
+@include md-register-theme("default", (
+        background: #f9f1f4
+));
+
+@import "../../../../node_modules/vue-material/dist/theme/all";

--- a/app/views/tasks/index.html.slim
+++ b/app/views/tasks/index.html.slim
@@ -27,26 +27,38 @@
           .submit
             button v-on:click="search" 検索
             button v-on:click="reset" 検索条件をリセット
-      table.table#paginated_tasks
-        tr
-          th.head scope="col" = t("actionview.task.index.title")
-          th.head scope="col" = t("actionview.task.index.importance")
-          th.head scope="col" = t("actionview.task.index.status")
-          th.head scope="col" = t("actionview.task.index.dead_line_on")
-          th.head scope="col" = t("actionview.task.index.detail")
-          th.head scope="col" = t("actionview.task.index.created_at_day")
-          th.head scope="col" = t("actionview.task.index.option")
-        tr.tasks v-for="task in tasks" v-bind:key="task.id"
-          th.title scope="row" = "{{task.title}}"
-          th.importance scope="row" = "{{task.importance.text}}"
-          th.status scope="row" = "{{task.status.text}}"
-          th.dead_line_on scope="row" = "{{task.dead_line_on}}"
-          th.detail scope="row" = "{{task.detail}}"
-          th.created_day scope="row" = "{{task.created_at}}"
-          th.each_task_links
-            .each_task_update_form_button
-              update-task-form v-bind:task="task"
-            .each_task_delete_button
-              button v-on:click="deleteTask(task.id)" 削除
-      v-paginator#paginator v-bind:options="options" resource_url="/api/tasks" v-on:update="updateResource"
+      /vue-materialのMdTableを用いて実装したもの
+      md-table v-model="tasks" md-sort="created_at" md-sort-order="asc"
+        md-table-row slot="md-table-row" slot-scope="{item}"
+          md-table-cell md-label="タイトル" {{item.title}}
+          md-table-cell md-label="優先順位" md-sort-by="importance.text" {{item.importance.text}}
+          md-table-cell md-label="状態" md-sort-by="status.text" {{ item.status.text }}
+          md-table-cell md-label="期限" md-sort-by="dead_line_on" {{ item.dead_line_on }}
+          md-table-cell md-label="説明文" {{ item.detail }}
+          md-table-cell md-label="作成日" md-sort-by="created_at" {{ item.created_at }}
+          update-task-form v-bind:task="item"
+
+      /vue-materialを用いない普通のテーブルで実装したもの。まだデザインが定まっておらず、変更の際に参考する可能性があるのでコメントアウトにして残している。
+      / table.table#paginated_tasks
+      /   tr
+      /     th.head scope="col" = t("actionview.task.index.title")
+      /     th.head scope="col" = t("actionview.task.index.importance")
+      /     th.head scope="col" = t("actionview.task.index.status")
+      /     th.head scope="col" = t("actionview.task.index.dead_line_on")
+      /     th.head scope="col" = t("actionview.task.index.detail")
+      /     th.head scope="col" = t("actionview.task.index.created_at_day")
+      /     th.head scope="col" = t("actionview.task.index.option")
+      /   tr.tasks v-for="task in tasks" v-bind:key="task.id"
+      /     th.title scope="row" = "{{task.title}}"
+      /     th.importance scope="row" = "{{task.importance.text}}"
+      /     th.status scope="row" = "{{task.status.text}}"
+      /     th.dead_line_on scope="row" = "{{task.dead_line_on}}"
+      /     th.detail scope="row" = "{{task.detail}}"
+      /     th.created_day scope="row" = "{{task.created_at}}"
+      /     th.each_task_links
+      /       .each_task_update_form_button
+      /         update-task-form v-bind:task="task"
+      /       .each_task_delete_button
+      /         button v-on:click="deleteTask(task.id)" 削除
+      / v-paginator#paginator v-bind:options="options" resource_url="/api/tasks" v-on:update="updateResource"
 = javascript_pack_tag 'tasks/index_vue'


### PR DESCRIPTION

![スクリーンショット 2019-06-28 17 35 25](https://user-images.githubusercontent.com/31206922/60329344-27674180-99cb-11e9-853c-e9cc198a039c.png)


## やったこと
- タスク一覧表示部分のテーブルにvue-materialを適用させる
- webpackerでnode_modules配下のCSSを読み込むようにする