### PR TITLE
新しい「問題を」追加できるようにする

### DIFF
--- a/app/controllers/api/issues_controller.rb
+++ b/app/controllers/api/issues_controller.rb
@@ -7,4 +7,19 @@ class Api::IssuesController < ApplicationController # rubocop:disable Style/Clas
     @issues = current_user.issues
     render json: @issues, status: 200
   end
+
+  def create
+    @issue = current_user.issues.new(issue_params)
+    if @issue.save
+      render json: @issue, status: 200
+    else
+      render json: @issue.errors.full_messasges, status: 400
+    end
+  end
+
+  private
+
+  def issue_params
+    params.permit(:title, :status, :dead_line_on, :user_id)
+  end
 end

--- a/app/controllers/api/issues_controller.rb
+++ b/app/controllers/api/issues_controller.rb
@@ -13,7 +13,7 @@ class Api::IssuesController < ApplicationController # rubocop:disable Style/Clas
     if @issue.save
       render json: @issue, status: 200
     else
-      render json: @issue.errors.full_messasges, status: 400
+      render json: @issue.errors.full_messages, status: 400
     end
   end
 

--- a/app/controllers/api/issues_controller.rb
+++ b/app/controllers/api/issues_controller.rb
@@ -9,7 +9,7 @@ class Api::IssuesController < ApplicationController # rubocop:disable Style/Clas
   end
 
   def create
-    @issue = current_user.issues.new(issue_params)
+    @issue = current_user.issues.build(issue_params)
     if @issue.save
       render json: @issue, status: 200
     else
@@ -20,6 +20,6 @@ class Api::IssuesController < ApplicationController # rubocop:disable Style/Clas
   private
 
   def issue_params
-    params.permit(:title, :status, :dead_line_on, :user_id)
+    params.permit(:title, :status, :dead_line_on)
   end
 end

--- a/app/frontend/packs/javascript/components/new_issue_form_component.js
+++ b/app/frontend/packs/javascript/components/new_issue_form_component.js
@@ -1,7 +1,8 @@
-import taskFormRequestable from '../modules/task_form_requestable';
+import requetByConfiguredAxios from '../modules/request_by_configured_axios';
+import toastr from 'toastr';
+import 'toastr/toastr.scss';
 
 export default {
-  mixins: [taskFormRequestable],
   data: function() {
     return {
       method: 'post',
@@ -10,25 +11,26 @@ export default {
       dead_line_on: '',
       status: '',
       newFormRendering: false,
+      processing_create_request: false,
     };
   },
   template: `<div>
                <div v-if="newFormRendering">
-                 <form v-on:submit.prevent="requestUrl">
+                 <form v-on:submit.prevent="createNewTask">
                    <div class="title_block">
                      <label for="title_input">タイトル：</label>
                      <input id="title_input" type="text" v-model="title">
                    </div>
                    <div class="dead_line_on_block">
                      <label for="dead_line_on_input">期限：</label>
-                     <input id="dead_line_on_input" type="date" v-model="dead_line_on">
+                     <input id="dead_line_on_input" type="date" min="2019-07-20" v-model="dead_line_on">
                    </div>
                    <div class="status_block">
                      <label for="status_select">状態：</label>
                      <select id="status_select" v-model="status">
-                       <option value="not_started">未着手</option>
-                       <option value="working">着手</option>
-                       <option value="completed">完了</option>
+                       <option value="未着手">未着手</option>
+                       <option value="着手">着手</option>
+                       <option value="完了">完了</option>
                      </select>
                    </div>
                    <div class="submit_block">
@@ -49,6 +51,38 @@ export default {
              </div>
              `,
   methods: {
+    createNewTask: function() {
+      requetByConfiguredAxios({method: this.method,
+                               url: this.request_url,
+                               requestParams: new URLSearchParams({'title': this.title,
+                                                                   'dead_line_on': this.dead_line_on,
+                                                                   'status': this.status}),
+                               withCsrf: true,
+                               withCookie: false}
+      ).then(()=> {
+        toastr.success('問題の追加に成功しました');
+        this.$root.getIssues();
+        this.initializeForm();
+      }).catch((error)=> {
+        error.response.data.forEach((message)=> {
+          toastr.error(message);
+        })
+      }).finally(()=> {
+        this.reloadForm(1000);
+      });
+    },
+    initializeForm: function() {
+      this.title = '';
+      this.dead_line_on = '';
+      this.status = '';
+    },
+    reloadForm: function(time) {
+      (new Promise((resolve)=> {
+        resolve(this.processing_create_request = true);
+      })).then(()=> {
+        setTimeout(()=> this.processing_create_request = false, time);
+      });
+    },
     switchNewFormRendering: function() {
       this.newFormRendering = !this.newFormRendering;
     },

--- a/app/frontend/packs/javascript/components/new_issue_form_component.js
+++ b/app/frontend/packs/javascript/components/new_issue_form_component.js
@@ -66,7 +66,7 @@ export default {
       }).catch((error)=> {
         error.response.data.forEach((message)=> {
           toastr.error(message);
-        })
+        });
       }).finally(()=> {
         this.reloadForm(1000);
       });

--- a/app/frontend/packs/javascript/issues_vue.js
+++ b/app/frontend/packs/javascript/issues_vue.js
@@ -1,14 +1,13 @@
 import Vue from 'vue/dist/vue.esm.js';
 import requestByConfiguredAxios from './modules/request_by_configured_axios';
 import toastr from 'toastr';
-import {MdContent, MdRipple, MdTable, MdCard, MdLayout, MdButton} from 'vue-material/dist/components';
+import {MdContent, MdRipple, MdCard, MdLayout, MdButton} from 'vue-material/dist/components';
 import '../stylesheets/application.scss';
 import eachIssue from './components/each_issue_component';
 import newIssueForm from './components/new_issue_form_component';
 
 Vue.use(MdRipple);
 Vue.use(MdContent);
-Vue.use(MdTable);
 Vue.use(MdCard);
 Vue.use(MdLayout);
 Vue.use(MdButton);

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -27,4 +27,12 @@ class Issue < ApplicationRecord
   belongs_to :user
 
   enum status: { 未着手: 0, 着手: 1, 完了: 2 }
+
+  validates :title, presence: true
+  validates :status, presence: true, inclusion: { in: %w(未着手 着手 完了) }
+  validate :dead_line_on_cannot_be_in_the_past
+
+  def dead_line_on_cannot_be_in_the_past
+    errors.add(:dead_line_on, 'は今日以降の日付を入力してください') if dead_line_on.present? && dead_line_on < Time.zone.today
+  end
 end

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -29,7 +29,7 @@ class Issue < ApplicationRecord
   enum status: { 未着手: 0, 着手: 1, 完了: 2 }
 
   validates :title, presence: true
-  validates :status, presence: true, inclusion: { in: %w(未着手 着手 完了) }
+  validates :status, inclusion: { in: %w(未着手 着手 完了) }
   validate :dead_line_on_cannot_be_in_the_past
 
   def dead_line_on_cannot_be_in_the_past

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,6 +2,7 @@ ja:
   activerecord:
     models:
       task: タスク
+      issue: イシュー
     attributes:
       task:
         title: タイトル
@@ -17,6 +18,10 @@ ja:
         not_started: "未着手"
         working: "着手"
         completed: "完了"
+      issue:
+        title: タイトル
+        dead_line_on: 期限
+        status: 状態
   actionview:
     task:
       index:

--- a/config/locales/ja.yml
+++ b/config/locales/ja.yml
@@ -2,7 +2,7 @@ ja:
   activerecord:
     models:
       task: タスク
-      issue: イシュー
+      issue: 問題
     attributes:
       task:
         title: タイトル

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
 
   namespace :api, format: 'json' do
     resources :tasks, only: %i(index create update destroy)
-    resources :issues, only: :index
+    resources :issues, only: %i(index create)
     get 'open_weather_maps', to: 'open_weather_maps#current_tokyo_weather'
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -21,6 +21,7 @@
 #                           PUT    /api/tasks/:id(.:format)                                                                 api/tasks#update {:format=>/json/}
 #                           DELETE /api/tasks/:id(.:format)                                                                 api/tasks#destroy {:format=>/json/}
 #                api_issues GET    /api/issues(.:format)                                                                    api/issues#index {:format=>/json/}
+#                           POST   /api/issues(.:format)                                                                    api/issues#create {:format=>/json/}
 #     api_open_weather_maps GET    /api/open_weather_maps(.:format)                                                         api/open_weather_maps#current_tokyo_weather {:format=>/json/}
 #        rails_service_blob GET    /rails/active_storage/blobs/:signed_id/*filename(.:format)                               active_storage/blobs#show
 # rails_blob_representation GET    /rails/active_storage/representations/:signed_blob_id/:variation_key/*filename(.:format) active_storage/representations#show

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -26,5 +26,46 @@
 require 'rails_helper'
 
 RSpec.describe Issue, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'Issueのバリデーション' do
+    let(:issue) { build(:issue, title: title, status: status, dead_line_on: dead_line_on) }
+    subject { issue.valid? }
+    describe ' Issueのtitle' do
+      let(:status) { '未着手' }
+      let(:dead_line_on) { Time.zone.tomorrow }
+      context 'titleが入力されていない場合' do
+        let(:title) { '' }
+        it { is_expected.to eq false }
+      end
+    end
+    describe 'Issueのstatus' do
+      let(:title) { 'test' }
+      let(:dead_line_on) { Time.zone.tomorrow }
+      context 'statusが入力されていない場合' do
+        let(:status) { '' }
+        it { is_expected.to eq false }
+      end
+      context 'statusが「未着手」、「着手」、「完了」以外の文字列の場合' do
+        let(:title) { 'test' }
+        let(:status) { '終了' }
+        let(:dead_line_on) { Time.zone.tomorrow }
+        it { is_expected_block.to raise_error(ArgumentError) }
+      end
+    end
+    describe 'Issueのdead_line_on' do
+      let(:title) { 'test' }
+      let(:status) { '未着手' }
+      context 'dead_line_onが過去の日付の場合' do
+        let(:dead_line_on) { Time.zone.yesterday }
+        it { is_expected.to eq false }
+      end
+      context 'dead_line_onが今日の日付の場合' do
+        let(:dead_line_on) { Time.zone.today }
+        it { is_expected.to eq true }
+      end
+      context 'dead_line_onが3年後の日付の場合' do
+        let(:dead_line_on) { Time.zone.today.since(3.years) }
+        it { is_expected.to eq true }
+      end
+    end
+  end
 end

--- a/spec/requests/api/issues_spec.rb
+++ b/spec/requests/api/issues_spec.rb
@@ -23,10 +23,6 @@ RSpec.describe 'Api::Issues', type: :request do
     end
   end
   describe '#create' do
-    let(:title) { 'test_title' }
-    let(:status) { '未着手' }
-    let(:dead_line_on) { '2019-09-21' }
-    let(:created_task) { JSON.parse(response.body) }
     before do
       post api_issues_path, params: {
         title: title,
@@ -34,9 +30,30 @@ RSpec.describe 'Api::Issues', type: :request do
         dead_line_on: dead_line_on
       }
     end
-    it '投稿に成功する' do
-      expect(created_task['title']).to eq 'test_title'
-      expect(response.status).to eq 200
+    context '全ての値が正常な場合' do
+      let(:created_task) { JSON.parse(response.body) }
+      let(:title) { 'test_title' }
+      let(:status) { '未着手' }
+      let(:dead_line_on) { Time.zone.tomorrow }
+      it '投稿に成功する' do
+        expect(created_task['title']).to eq 'test_title'
+      end
+      it '200のステータスを返す' do
+        expect(response.status).to eq 200
+      end
+    end
+    context '不正な値がある場合' do
+      let(:error_messages) { JSON.parse(response.body) }
+      let(:title) { '' }
+      let(:status) { '未着手' }
+      let(:dead_line_on) { Time.zone.yesterday }
+      it '該当するエラーメッセージを返す' do
+        expect(error_messages).to include 'タイトルを入力してください'
+        expect(error_messages).to include '期限は今日以降の日付を入力してください'
+      end
+      it '400のステータスを返す' do
+        expect(response.status).to eq 400
+      end
     end
   end
 end

--- a/spec/requests/api/issues_spec.rb
+++ b/spec/requests/api/issues_spec.rb
@@ -22,4 +22,21 @@ RSpec.describe 'Api::Issues', type: :request do
       expect(response.status).to eq 200
     end
   end
+  describe '#create' do
+    let(:title) { 'test_title' }
+    let(:status) { '未着手' }
+    let(:dead_line_on) { '2019-09-21' }
+    let(:created_task) { JSON.parse(response.body) }
+    before do
+      post api_issues_path, params: {
+        title: title,
+        status: status,
+        dead_line_on: dead_line_on
+      }
+    end
+    it '投稿に成功する' do
+      expect(created_task['title']).to eq 'test_title'
+      expect(response.status).to eq 200
+    end
+  end
 end


### PR DESCRIPTION
## やったこと
- api側でIssueを追加できるようにする
- フロント側のフォームからapiにリクエストを投げられるようにする
  - 投稿に成功した場合、フォームに何も入力されていない状態に戻す
- 投稿の成功、失敗をtoastrで伝えるようにする

## 実際の挙動
![問題を投稿する機能を追加](https://user-images.githubusercontent.com/31206922/61939828-195b0f80-afcf-11e9-9b78-ceddbe57ecb4.gif)

## 関連するissue
#154 