### PR TITLE
issueの一覧画面に表示している各issueから、そのissueの詳細画面に遷移できるようにする

### DIFF
--- a/app/frontend/packs/javascript/components/each_issue_component.js
+++ b/app/frontend/packs/javascript/components/each_issue_component.js
@@ -2,11 +2,13 @@ export default {
   props: ['issue'],
   template: `
             <md-card class="each_issue">
-              <md-card-content>
-                <h4 class="issue_title">
-                  {{issue.title}}
-                </h4>
-              </md-card-content>
+              <a class="issue_link" href="/issues/{{issue.id}}">
+                <md-card-content>
+                  <h4 class="issue_title">
+                    {{issue.title}}
+                  </h4>
+                </md-card-content>
+              </a>
               <md-card-actions class="md-alignment-left">
                 <div class="issue_status">
                   <md-button class="md-primary">

--- a/app/frontend/packs/stylesheets/_issues.scss
+++ b/app/frontend/packs/stylesheets/_issues.scss
@@ -38,4 +38,8 @@
 .each_issue {
   margin-top: 48px;
   margin-bottom: 24px;
+  .issue_link {
+    color: #ffffff !important;
+    text-decoration: none !important;
+  }
 }

--- a/app/views/issues/index.html.slim
+++ b/app/views/issues/index.html.slim
@@ -5,18 +5,19 @@
     .status_filter_box.col-lg-4.col-md-4.offset-md-8
       select.status_select
         option[disabled value=""]
-          | 問題のステータスを選択してください
+          | 表示したい問題のステータス
         option
-          | A
+          | 選択しない
         option
-          | B
+          | 未着手
         option
-          | C
+          | 着手
+        option
+          | 完了
   .container
     .issues
       .md-layout.md-gutter
         .md-layout-item.md-medium-size-100.md-xsmall-size-100.md-size-33 v-for="issue in issues"
           each-issue v-bind:issue="issue"
-
 
 = javascript_pack_tag 'javascript/issues_vue.js'

--- a/app/views/issues/show.html.slim
+++ b/app/views/issues/show.html.slim
@@ -2,7 +2,7 @@
   .container-fluid
     .title_box
       h4.hoge
-        | あるLinuxコマンドを別のLinuxディストリビューションでも動かしたい
+        | 冷蔵庫の中身を管理したい
     #steps.row.steps_box
       .col-lg-4.col-md-12
         .step_title_box


### PR DESCRIPTION
## やったこと
- 一覧画面で表示している各issueからissueの詳細画面に移動できるようにする

- 実際の動き
![一覧画面から詳細画面に移動](https://user-images.githubusercontent.com/31206922/62114201-20e12800-b2f1-11e9-9801-c0eba809c443.gif)
