### PR TITLE
Stepモデルを作成し、Issueが投稿された後、投稿されたIssueに紐付くステップが3つ作成されるようにする

### DIFF
--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -24,6 +24,7 @@
 #
 
 class Issue < ApplicationRecord
+  has_many :steps
   belongs_to :user
 
   enum status: { 未着手: 0, 着手: 1, 完了: 2 }

--- a/app/models/issue.rb
+++ b/app/models/issue.rb
@@ -32,8 +32,15 @@ class Issue < ApplicationRecord
   validates :title, presence: true
   validates :status, inclusion: { in: %w(未着手 着手 完了) }
   validate :dead_line_on_cannot_be_in_the_past
+  after_create :create_associated_three_steps
 
   def dead_line_on_cannot_be_in_the_past
     errors.add(:dead_line_on, 'は今日以降の日付を入力してください') if dead_line_on.present? && dead_line_on < Time.zone.today
+  end
+
+  private
+
+  def create_associated_three_steps
+    Step.import [self.steps.new(title: 'ステップ'), self.steps.new(title: 'ステップ'), self.steps.new(title: 'ステップ')], validate: true
   end
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -6,7 +6,19 @@
 #  title      :string(255)      not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  issue_id   :bigint
+#
+# Indexes
+#
+#  index_steps_on_issue_id  (issue_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (issue_id => issues.id)
 #
 
 class Step < ApplicationRecord
+  belongs_to :issue
+
+  validates :title, presence: true
 end

--- a/app/models/step.rb
+++ b/app/models/step.rb
@@ -1,0 +1,12 @@
+# == Schema Information
+#
+# Table name: steps
+#
+#  id         :bigint           not null, primary key
+#  title      :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+class Step < ApplicationRecord
+end

--- a/db/migrate/20190801082733_create_steps.rb
+++ b/db/migrate/20190801082733_create_steps.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class CreateSteps < ActiveRecord::Migration[5.2]
+  def change
+    create_table :steps do |t|
+      t.string :title, null: false
+      t.references 
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20190801082733_create_steps.rb
+++ b/db/migrate/20190801082733_create_steps.rb
@@ -4,7 +4,6 @@ class CreateSteps < ActiveRecord::Migration[5.2]
   def change
     create_table :steps do |t|
       t.string :title, null: false
-      t.references 
       t.timestamps
     end
   end

--- a/db/migrate/20190802022711_add_issue_id_to_steps.rb
+++ b/db/migrate/20190802022711_add_issue_id_to_steps.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddIssueIdToSteps < ActiveRecord::Migration[5.2]
+  def change
+    add_reference :steps, :issue, foreign_key: true, on_delete: :cascade, comment: '「問題」のidと紐づけられる。「問題」が削除された場合、その「問題」に投稿された「ステップ」も削除される'
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,3 +1,5 @@
+# frozen_string_literal: true
+
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -10,44 +12,53 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_07_25_081359) do
+ActiveRecord::Schema.define(version: 2019_08_02_022711) do
 
-  create_table "issues", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "title", null: false
-    t.integer "status", default: 0
-    t.date "dead_line_on", null: false
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.bigint "user_id", comment: "「問題」を投稿したユーザーのidと紐づけられる。投稿したユーザーが削除された場合、そのユーザーが投稿した「問題」も削除される"
-    t.index ["status"], name: "index_issues_on_status"
-    t.index ["title"], name: "index_issues_on_title"
-    t.index ["user_id"], name: "index_issues_on_user_id"
+  create_table 'issues', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'title', null: false
+    t.integer 'status', default: 0
+    t.date 'dead_line_on', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.bigint 'user_id', comment: '「問題」を投稿したユーザーのidと紐づけられる。投稿したユーザーが削除された場合、そのユーザーが投稿した「問題」も削除される'
+    t.index ['status'], name: 'index_issues_on_status'
+    t.index ['title'], name: 'index_issues_on_title'
+    t.index ['user_id'], name: 'index_issues_on_user_id'
   end
 
-  create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.bigint "user_id", comment: "タスクを投稿したユーザーのidと紐づけられる。投稿したユーザーが削除された場合、そのユーザーが投稿したタスクも削除される"
-    t.string "title", null: false, comment: "タスク名"
-    t.integer "importance", default: 0, comment: "タスクの優先度"
-    t.date "dead_line_on", comment: "タスクの期限"
-    t.integer "status", default: 0, comment: "タスクの進捗"
-    t.text "detail", comment: "タスクの詳細"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.index ["status"], name: "index_tasks_on_status"
-    t.index ["title"], name: "index_tasks_on_title"
-    t.index ["user_id"], name: "index_tasks_on_user_id"
+  create_table 'steps', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'title', null: false
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.bigint 'issue_id', comment: '「問題」のidと紐づけられる。「問題」が削除された場合、その「問題」に投稿された「ステップ」も削除される'
+    t.index ['issue_id'], name: 'index_steps_on_issue_id'
   end
 
-  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-    t.string "name", null: false, comment: "ユーザーの本名"
-    t.string "accountid", default: "0", null: false, comment: "ユーザーのアカウントID、ユーザー固有の値"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
-    t.string "hashed_password", null: false, comment: "ハッシュ化されたユーザーのパスワード"
-    t.string "hashed_cookie_token", comment: "ユーザーのログイン時に使用されるcookiesトークンを暗号化したもの"
-    t.string "salt", null: false, comment: "パスワードハッシュ化の際に用いるデータ"
+  create_table 'tasks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.bigint 'user_id', comment: 'タスクを投稿したユーザーのidと紐づけられる。投稿したユーザーが削除された場合、そのユーザーが投稿したタスクも削除される'
+    t.string 'title', null: false, comment: 'タスク名'
+    t.integer 'importance', default: 0, comment: 'タスクの優先度'
+    t.date 'dead_line_on', comment: 'タスクの期限'
+    t.integer 'status', default: 0, comment: 'タスクの進捗'
+    t.text 'detail', comment: 'タスクの詳細'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.index ['status'], name: 'index_tasks_on_status'
+    t.index ['title'], name: 'index_tasks_on_title'
+    t.index ['user_id'], name: 'index_tasks_on_user_id'
   end
 
-  add_foreign_key "issues", "users"
-  add_foreign_key "tasks", "users"
+  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
+    t.string 'name', null: false, comment: 'ユーザーの本名'
+    t.string 'accountid', default: '0', null: false, comment: 'ユーザーのアカウントID、ユーザー固有の値'
+    t.datetime 'created_at', null: false
+    t.datetime 'updated_at', null: false
+    t.string 'hashed_password', null: false, comment: 'ハッシュ化されたユーザーのパスワード'
+    t.string 'hashed_cookie_token', comment: 'ユーザーのログイン時に使用されるcookiesトークンを暗号化したもの'
+    t.string 'salt', null: false, comment: 'パスワードハッシュ化の際に用いるデータ'
+  end
+
+  add_foreign_key 'issues', 'users'
+  add_foreign_key 'steps', 'issues'
+  add_foreign_key 'tasks', 'users'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -1,5 +1,3 @@
-# frozen_string_literal: true
-
 # This file is auto-generated from the current state of the database. Instead
 # of editing this file, please use the migrations feature of Active Record to
 # incrementally modify your database, and then regenerate this schema definition.
@@ -13,42 +11,43 @@
 # It's strongly recommended that you check this file into your version control system.
 
 ActiveRecord::Schema.define(version: 2019_07_25_081359) do
-  create_table 'issues', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'title', null: false
-    t.integer 'status', default: 0
-    t.date 'dead_line_on', null: false
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.bigint 'user_id', comment: '「問題」を投稿したユーザーのidと紐づけられる。投稿したユーザーが削除された場合、そのユーザーが投稿した「問題」も削除される'
-    t.index ['status'], name: 'index_issues_on_status'
-    t.index ['title'], name: 'index_issues_on_title'
-    t.index ['user_id'], name: 'index_issues_on_user_id'
+
+  create_table "issues", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "title", null: false
+    t.integer "status", default: 0
+    t.date "dead_line_on", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.bigint "user_id", comment: "「問題」を投稿したユーザーのidと紐づけられる。投稿したユーザーが削除された場合、そのユーザーが投稿した「問題」も削除される"
+    t.index ["status"], name: "index_issues_on_status"
+    t.index ["title"], name: "index_issues_on_title"
+    t.index ["user_id"], name: "index_issues_on_user_id"
   end
 
-  create_table 'tasks', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.bigint 'user_id', comment: 'タスクを投稿したユーザーのidと紐づけられる。投稿したユーザーが削除された場合、そのユーザーが投稿したタスクも削除される'
-    t.string 'title', null: false, comment: 'タスク名'
-    t.integer 'importance', default: 0, comment: 'タスクの優先度'
-    t.date 'dead_line_on', comment: 'タスクの期限'
-    t.integer 'status', default: 0, comment: 'タスクの進捗'
-    t.text 'detail', comment: 'タスクの詳細'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.index ['status'], name: 'index_tasks_on_status'
-    t.index ['title'], name: 'index_tasks_on_title'
-    t.index ['user_id'], name: 'index_tasks_on_user_id'
+  create_table "tasks", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.bigint "user_id", comment: "タスクを投稿したユーザーのidと紐づけられる。投稿したユーザーが削除された場合、そのユーザーが投稿したタスクも削除される"
+    t.string "title", null: false, comment: "タスク名"
+    t.integer "importance", default: 0, comment: "タスクの優先度"
+    t.date "dead_line_on", comment: "タスクの期限"
+    t.integer "status", default: 0, comment: "タスクの進捗"
+    t.text "detail", comment: "タスクの詳細"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["status"], name: "index_tasks_on_status"
+    t.index ["title"], name: "index_tasks_on_title"
+    t.index ["user_id"], name: "index_tasks_on_user_id"
   end
 
-  create_table 'users', options: 'ENGINE=InnoDB DEFAULT CHARSET=utf8', force: :cascade do |t|
-    t.string 'name', null: false, comment: 'ユーザーの本名'
-    t.string 'accountid', default: '0', null: false, comment: 'ユーザーのアカウントID、ユーザー固有の値'
-    t.datetime 'created_at', null: false
-    t.datetime 'updated_at', null: false
-    t.string 'hashed_password', null: false, comment: 'ハッシュ化されたユーザーのパスワード'
-    t.string 'hashed_cookie_token', comment: 'ユーザーのログイン時に使用されるcookiesトークンを暗号化したもの'
-    t.string 'salt', null: false, comment: 'パスワードハッシュ化の際に用いるデータ'
+  create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "name", null: false, comment: "ユーザーの本名"
+    t.string "accountid", default: "0", null: false, comment: "ユーザーのアカウントID、ユーザー固有の値"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.string "hashed_password", null: false, comment: "ハッシュ化されたユーザーのパスワード"
+    t.string "hashed_cookie_token", comment: "ユーザーのログイン時に使用されるcookiesトークンを暗号化したもの"
+    t.string "salt", null: false, comment: "パスワードハッシュ化の際に用いるデータ"
   end
 
-  add_foreign_key 'issues', 'users'
-  add_foreign_key 'tasks', 'users'
+  add_foreign_key "issues", "users"
+  add_foreign_key "tasks", "users"
 end

--- a/spec/factories/steps.rb
+++ b/spec/factories/steps.rb
@@ -6,10 +6,20 @@
 #  title      :string(255)      not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  issue_id   :bigint
+#
+# Indexes
+#
+#  index_steps_on_issue_id  (issue_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (issue_id => issues.id)
 #
 
 FactoryBot.define do
   factory :step do
-    
+    issue
+    title { 'ステップ' }
   end
 end

--- a/spec/factories/steps.rb
+++ b/spec/factories/steps.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: steps
+#
+#  id         :bigint           not null, primary key
+#  title      :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+FactoryBot.define do
+  factory :step do
+    
+  end
+end

--- a/spec/models/issue_spec.rb
+++ b/spec/models/issue_spec.rb
@@ -68,4 +68,12 @@ RSpec.describe Issue, type: :model do
       end
     end
   end
+  describe 'Issueのコールバック' do
+    describe '#create_associated_three_steps' do
+      let(:issue) { create(:issue) }
+      it '投稿したIssueに紐づくステップが3つ作成される' do
+        expect(issue.steps.count).to eq 3
+      end
+    end
+  end
 end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -1,0 +1,15 @@
+# == Schema Information
+#
+# Table name: steps
+#
+#  id         :bigint           not null, primary key
+#  title      :string(255)      not null
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#
+
+require 'rails_helper'
+
+RSpec.describe Step, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/step_spec.rb
+++ b/spec/models/step_spec.rb
@@ -6,10 +6,30 @@
 #  title      :string(255)      not null
 #  created_at :datetime         not null
 #  updated_at :datetime         not null
+#  issue_id   :bigint
+#
+# Indexes
+#
+#  index_steps_on_issue_id  (issue_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (issue_id => issues.id)
 #
 
 require 'rails_helper'
 
 RSpec.describe Step, type: :model do
-  pending "add some examples to (or delete) #{__FILE__}"
+  describe 'Stepのバリデーション' do
+    let(:step) { build(:step, title: title) }
+    subject { step.valid? }
+    context 'タイトルが入力されている場合' do
+      let(:title) { 'ステップ' }
+      it { is_expected. to eq true }
+    end
+    context 'タイトルが入力されていない場合' do
+      let(:title) { '' }
+      it { is_expected. to eq false }
+    end
+  end
 end


### PR DESCRIPTION
## やったこと
- Stepモデルを作成し、バリデーションを設定する
- Issueが投稿された時、投稿されたIssueに紐付くStepが3つ作成されるようにする
  - Stepを作成する際、 gem activerecord-importを使って、BULK_INSERTしているので、作成される Inser文は1つになるようにしている

## mergeする際の注意点
- この作業ブランチから、「作成されたStepを画面に表示する」作業を行うブランチを切るので、squash_merge ではなく、普通のmergeを行って欲しいです